### PR TITLE
string parsing improvements in swarms.json

### DIFF
--- a/src/mail/api.py
+++ b/src/mail/api.py
@@ -30,7 +30,7 @@ from mail.core import (
 from mail.core.actions import ActionCore
 from mail.core.agents import AgentCore
 from mail.net import SwarmRegistry
-from mail.utils import read_python_string
+from mail.utils import read_python_string, resolve_python_references
 
 logger = logging.getLogger("mail")
 
@@ -237,7 +237,7 @@ class MAILAgentTemplate:
 			MAILAction.from_swarm_json(json.dumps(action))
 			for action in data.get("actions", [])
 		]
-		agent_params = data["agent_params"]
+		agent_params = resolve_python_references(data["agent_params"])
 		enable_entrypoint = data.get("enable_entrypoint", False)
 		enable_interswarm = data.get("enable_interswarm", False)
 		tool_format = data.get("tool_format", "responses")

--- a/src/mail/utils/__init__.py
+++ b/src/mail/utils/__init__.py
@@ -15,6 +15,7 @@ from .logger import (
 )
 from .parsing import (
 	read_python_string,
+	resolve_python_references,
 	target_address_is_interswarm,
 )
 from .store import (
@@ -29,6 +30,7 @@ __all__ = [
 	"get_loggers",
 	"init_logger",
 	"read_python_string",
+	"resolve_python_references",
 	"target_address_is_interswarm",
 	"get_langmem_store",
 	"caller_is_admin",

--- a/src/mail/utils/parsing.py
+++ b/src/mail/utils/parsing.py
@@ -6,7 +6,6 @@ from typing import Any
 
 from mail.core import parse_agent_address
 
-
 PYTHON_STRING_PREFIX = "python::"
 
 
@@ -33,11 +32,14 @@ def read_python_string(string: str) -> Any:
 	obj: Any = module
 	for attr in attribute_path.split("."):
 		obj = getattr(obj, attr)
+
 	return obj
 
 
 def resolve_python_references(value: Any) -> Any:
-	"""Recursively resolve strings prefixed with ``python::`` to Python objects."""
+	"""
+	Recursively resolve strings prefixed with ``python::`` to Python objects.
+	"""
 
 	if isinstance(value, dict):
 		return {key: resolve_python_references(item) for key, item in value.items()}
@@ -45,6 +47,7 @@ def resolve_python_references(value: Any) -> Any:
 		return [resolve_python_references(item) for item in value]
 	if isinstance(value, str) and value.startswith(PYTHON_STRING_PREFIX):
 		return read_python_string(value)
+		
 	return value
 
 

--- a/src/mail/utils/parsing.py
+++ b/src/mail/utils/parsing.py
@@ -7,14 +7,45 @@ from typing import Any
 from mail.core import parse_agent_address
 
 
+PYTHON_STRING_PREFIX = "python::"
+
+
 def read_python_string(string: str) -> Any:
 	"""
-	Read a python variable from a python file
-	The string should be in the format of "module:variable"
+	Resolve an import string to a Python object.
+
+	Accepts strings in the format ``module:variable`` or with the explicit
+	``python::`` prefix used in swarm configuration files, e.g.
+	``python::package.module:object``.
 	"""
-	module_str, variable = string.split(":")
+
+	if string.startswith(PYTHON_STRING_PREFIX):
+		string = string[len(PYTHON_STRING_PREFIX) :]
+
+	try:
+		module_str, attribute_path = string.split(":", 1)
+	except ValueError as err:  # pragma: no cover - defensive guard
+		raise ValueError(
+			f"Invalid python reference '{string}'. Expected 'module:object' format."
+		) from err
+
 	module = importlib.import_module(module_str)
-	return getattr(module, variable)
+	obj: Any = module
+	for attr in attribute_path.split("."):
+		obj = getattr(obj, attr)
+	return obj
+
+
+def resolve_python_references(value: Any) -> Any:
+	"""Recursively resolve strings prefixed with ``python::`` to Python objects."""
+
+	if isinstance(value, dict):
+		return {key: resolve_python_references(item) for key, item in value.items()}
+	if isinstance(value, list):
+		return [resolve_python_references(item) for item in value]
+	if isinstance(value, str) and value.startswith(PYTHON_STRING_PREFIX):
+		return read_python_string(value)
+	return value
 
 
 def target_address_is_interswarm(address: str) -> bool:

--- a/swarms.json
+++ b/swarms.json
@@ -7,18 +7,18 @@
         "agents": [
             {
                 "name": "supervisor",
-                "factory": "mail.factories.supervisor:supervisor_factory",
+                "factory": "python::mail.factories.supervisor:supervisor_factory",
                 "comm_targets": ["weather", "math"],
                 "enable_entrypoint": true,
                 "can_complete_tasks": true,
                 "agent_params": { 
                     "llm": "openai/gpt-5-mini",
-                    "system": "mail.examples.supervisor.prompts:SYSPROMPT"
+                    "system": "python::mail.examples.supervisor.prompts:SYSPROMPT"
                 }
             },
             {
                 "name": "weather",
-                "factory": "mail.examples.weather_dummy.agent:factory_weather_dummy",
+                "factory": "python::mail.examples.weather_dummy.agent:factory_weather_dummy",
                 "comm_targets": ["supervisor", "math"],
                 "actions": [
                     {
@@ -32,21 +32,21 @@
                                 "metric": { "type": "boolean", "description": "Whether to use metric units" }
                             }
                         },
-                        "function": "mail.examples.weather_dummy.actions:get_weather_forecast"
+                        "function": "python::mail.examples.weather_dummy.actions:get_weather_forecast"
                     }
                 ],
                 "agent_params": { 
                     "llm": "openai/gpt-5-mini",
-                    "system": "mail.examples.weather_dummy.prompts:SYSPROMPT"
+                    "system": "python::mail.examples.weather_dummy.prompts:SYSPROMPT"
                 }
             },
             {
                 "name": "math",
-                "factory": "mail.examples.math_dummy.agent:factory_math_dummy",
+                "factory": "python::mail.examples.math_dummy.agent:factory_math_dummy",
                 "comm_targets": ["supervisor", "weather"],
                 "agent_params": { 
                     "llm": "openai/gpt-5-mini",
-                    "system": "mail.examples.math_dummy.prompts:SYSPROMPT"
+                    "system": "python::mail.examples.math_dummy.prompts:SYSPROMPT"
                 }
             }
         ]
@@ -59,20 +59,20 @@
         "agents": [
             {
                 "name": "supervisor",
-                "factory": "mail.factories.supervisor:supervisor_factory",
+                "factory": "python::mail.factories.supervisor:supervisor_factory",
                 "comm_targets": ["weather", "math"],
                 "enable_entrypoint": true,
                 "enable_interswarm": true,
                 "can_complete_tasks": true,
                 "agent_params": { 
                     "llm": "openai/gpt-5-mini",
-                    "system": "mail.examples.supervisor.prompts:SYSPROMPT",
+                    "system": "python::mail.examples.supervisor.prompts:SYSPROMPT",
                     "use_proxy": false
                 }
             },
             {
                 "name": "weather",
-                "factory": "mail.examples.weather_dummy.agent:factory_weather_dummy",
+                "factory": "python::mail.examples.weather_dummy.agent:factory_weather_dummy",
                 "comm_targets": ["supervisor", "math"],
                 "actions": [
                     {
@@ -86,22 +86,22 @@
                                 "metric": { "type": "boolean", "description": "Whether to use metric units" }
                             }
                         },
-                        "function": "mail.examples.weather_dummy.actions:get_weather_forecast"
+                        "function": "python::mail.examples.weather_dummy.actions:get_weather_forecast"
                     }
                 ],
                 "agent_params": { 
                     "llm": "openai/gpt-5-mini",
-                    "system": "mail.examples.weather_dummy.prompts:SYSPROMPT",
+                    "system": "python::mail.examples.weather_dummy.prompts:SYSPROMPT",
                     "use_proxy": false
                 }
             },
             {
                 "name": "math",
-                "factory": "mail.examples.math_dummy.agent:factory_math_dummy",
+                "factory": "python::mail.examples.math_dummy.agent:factory_math_dummy",
                 "comm_targets": ["supervisor", "weather"],
                 "agent_params": { 
                     "llm": "openai/gpt-5-mini",
-                    "system": "mail.examples.math_dummy.prompts:SYSPROMPT",
+                    "system": "python::mail.examples.math_dummy.prompts:SYSPROMPT",
                     "use_proxy": false
                 }
             }
@@ -116,24 +116,24 @@
         "agents": [
             {
                 "name": "supervisor",
-                "factory": "mail.factories.supervisor:supervisor_factory",
+                "factory": "python::mail.factories.supervisor:supervisor_factory",
                 "comm_targets": ["weather", "math", "supervisor@swarm-beta"],
                 "enable_entrypoint": true,
                 "enable_interswarm": true,
                 "can_complete_tasks": true,
                 "agent_params": { 
                     "llm": "openai/gpt-5-mini",
-                    "system": "mail.examples.supervisor.prompts:SYSPROMPT",
+                    "system": "python::mail.examples.supervisor.prompts:SYSPROMPT",
                     "use_proxy": false
                 }
             },
             {
                 "name": "weather",
-                "factory": "mail.examples.weather_dummy.agent:factory_weather_dummy",
+                "factory": "python::mail.examples.weather_dummy.agent:factory_weather_dummy",
                 "comm_targets": ["supervisor", "math"],
                 "agent_params": { 
                     "llm": "openai/gpt-5-mini",
-                    "system": "mail.examples.weather_dummy.prompts:SYSPROMPT",
+                    "system": "python::mail.examples.weather_dummy.prompts:SYSPROMPT",
                     "use_proxy": false
                 },
                 "actions": [
@@ -148,17 +148,17 @@
                                 "metric": { "type": "boolean", "description": "Whether to use metric units" }
                             }
                         },
-                        "function": "mail.examples.weather_dummy.actions:get_weather_forecast"
+                        "function": "python::mail.examples.weather_dummy.actions:get_weather_forecast"
                     }
                 ]
             },
             {
                 "name": "math",
-                "factory": "mail.examples.math_dummy.agent:factory_math_dummy",
+                "factory": "python::mail.examples.math_dummy.agent:factory_math_dummy",
                 "comm_targets": ["supervisor", "weather"],
                 "agent_params": { 
                     "llm": "openai/gpt-5-mini",
-                    "system": "mail.examples.math_dummy.prompts:SYSPROMPT",
+                    "system": "python::mail.examples.math_dummy.prompts:SYSPROMPT",
                     "use_proxy": false
                 }
             }
@@ -173,34 +173,34 @@
         "agents": [
             {
                 "name": "supervisor",
-                "factory": "mail.factories.supervisor:supervisor_factory",
+                "factory": "python::mail.factories.supervisor:supervisor_factory",
                 "comm_targets": ["consultant", "analyst", "supervisor@swarm-alpha"],
                 "enable_entrypoint": true,
                 "enable_interswarm": true,
                 "can_complete_tasks": true,
                 "agent_params": { 
                     "llm": "openai/gpt-5-mini",
-                    "system": "mail.examples.supervisor.prompts:SYSPROMPT",
+                    "system": "python::mail.examples.supervisor.prompts:SYSPROMPT",
                     "use_proxy": false
                 }
             },
             {
                 "name": "consultant",
-                "factory": "mail.examples.consultant_dummy.agent:factory_consultant_dummy",
+                "factory": "python::mail.examples.consultant_dummy.agent:factory_consultant_dummy",
                 "comm_targets": ["supervisor", "analyst"],
                 "agent_params": { 
                     "llm": "openai/gpt-5-mini",
-                    "system": "mail.examples.consultant_dummy.prompts:SYSPROMPT",
+                    "system": "python::mail.examples.consultant_dummy.prompts:SYSPROMPT",
                     "use_proxy": false
                 }
             },
             {
                 "name": "analyst",
-                "factory": "mail.examples.analyst_dummy.agent:factory_analyst_dummy",
+                "factory": "python::mail.examples.analyst_dummy.agent:factory_analyst_dummy",
                 "comm_targets": ["supervisor", "consultant"],
                 "agent_params": { 
                     "llm": "openai/gpt-5-mini",
-                    "system": "mail.examples.analyst_dummy.prompts:SYSPROMPT",
+                    "system": "python::mail.examples.analyst_dummy.prompts:SYSPROMPT",
                     "use_proxy": false
                 }
             }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,6 @@ from typing import Any, Literal
 
 import pytest
 
-
 TEST_SYSTEM_PROMPT = "Resolved via python import"
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,9 @@ from typing import Any, Literal
 import pytest
 
 
+TEST_SYSTEM_PROMPT = "Resolved via python import"
+
+
 class FakeSwarmRegistry:
 	"""
 	Fake `SwarmRegistry` for testing.

--- a/tests/unit/test_mail_api.py
+++ b/tests/unit/test_mail_api.py
@@ -9,7 +9,7 @@ import pytest
 from pydantic import ValidationError
 
 from mail.api import MAILAction, MAILAgent
-from tests.conftest import make_stub_agent
+from tests.conftest import TEST_SYSTEM_PROMPT, make_stub_agent
 
 
 class FakeMAIL:
@@ -133,6 +133,34 @@ def test_from_swarm_json_valid_creates_swarm() -> None:
 	assert isinstance(swarm._runtime, FakeMAIL)
 	assert swarm._runtime.user_id == "u-1"
 	assert swarm._runtime.swarm_name == "myswarm"
+
+
+def test_agent_params_prefixed_python_strings_resolved() -> None:
+	"""Ensure agent_params values with the python prefix are resolved."""
+	from mail import MAILSwarmTemplate
+
+	data = {
+		"name": "myswarm",
+		"agents": [
+			{
+				"name": "supervisor",
+				"factory": "tests.conftest:make_stub_agent",
+				"comm_targets": ["supervisor"],
+				"can_complete_tasks": True,
+				"actions": [],
+				"enable_entrypoint": True,
+				"agent_params": {
+					"system": "python::tests.conftest:TEST_SYSTEM_PROMPT",
+				},
+			},
+		],
+		"actions": [],
+		"entrypoint": "supervisor",
+	}
+
+	tmpl = MAILSwarmTemplate.from_swarm_json(json.dumps(data))
+	agent = tmpl.agents[0]
+	assert agent.agent_params["system"] == TEST_SYSTEM_PROMPT
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_mail_api.py
+++ b/tests/unit/test_mail_api.py
@@ -136,7 +136,9 @@ def test_from_swarm_json_valid_creates_swarm() -> None:
 
 
 def test_agent_params_prefixed_python_strings_resolved() -> None:
-	"""Ensure agent_params values with the python prefix are resolved."""
+	"""
+	Ensure agent_params values with the python prefix are resolved.
+	"""
 	from mail import MAILSwarmTemplate
 
 	data = {


### PR DESCRIPTION
- previously, Python import strings inside `agent_params` would not be parsed at all
- now, in order to be parsed, Python import strings as values inside `agent_params` MUST be prefixed by 'python::'