### PR TITLE
Tasks now first-class objects; previous ones can be resumed by user after breakpoints

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -17,19 +17,20 @@ The server exposes a [FastAPI application](/src/mail/server.py) with endpoints f
 | --- | --- | --- | --- | --- | --- |
 | GET | `/` | None (public) | `None` | `types.GetRootResponse { name, status, version }` | Returns MAIL service metadata and version string |
 | GET | `/status` | `Bearer` token with role `admin` or `user` | `None` | `types.GetStatusResponse { swarm, active_users, user_mail_ready, user_task_running }` | Reports persistent swarm readiness and whether the caller already has a running runtime |
-| POST | `/message` | `Bearer` token with role `admin` or `user` | `JSON { message: str, entrypoint?: str, show_events?: bool, stream?: bool }` | `types.PostMessageResponse { response: str, events?: list[ServerSentEvent] }` (or `text/event-stream` when `stream: true`) | Queues a user-scoped task, optionally returning runtime events or an SSE stream |
+| POST | `/message` | `Bearer` token with role `admin` or `user` | `JSON { subject: str, body: str, msg_type?: str, entrypoint?: str, show_events?: bool, stream?: bool, task_id?: str, resume_from?: str, kwargs?: dict }` | `types.PostMessageResponse { response: str, events?: list[ServerSentEvent] }` (or `text/event-stream` when `stream: true`) | Queues or resumes a user-scoped task; supports breakpoint resumes via `resume_from="breakpoint_tool_call"` and extra kwargs |
 | GET | `/health` | None (public) | `None` | `types.GetHealthResponse { status, swarm_name, timestamp }` | Liveness signal used for interswarm discovery |
 | GET | `/swarms` | None (public) | `None` | `types.GetSwarmsResponse { swarms: list[types.SwarmEndpoint] }` | Lists swarms known to the local registry |
 | POST | `/swarms` | `Bearer` token with role `admin` | `JSON { name: str, base_url: str, auth_token?: str, metadata?: dict, volatile?: bool }` | `types.PostSwarmsResponse { status, swarm_name }` | Registers a remote swarm (persistent when `volatile` is `False`) |
 | GET | `/swarms/dump` | `Bearer` token with role `admin` | `None` | `types.GetSwarmsDumpResponse { status, swarm_name }` | Logs the configured persistent swarm and returns acknowledgement |
 | POST | `/interswarm/message` | `Bearer` token with role `agent` | `MAILInterswarmMessage { message_id, source_swarm, target_swarm, payload, ... }` | `MAILMessage` (task response) | Routes an inbound interswarm request into the local runtime and returns the generated response |
 | POST | `/interswarm/response` | `Bearer` token with role `agent` | `MAILMessage { id, msg_type, message }` | `types.PostInterswarmResponseResponse { status, task_id }` | Injects a remote swarm response into the pending task queue |
-| POST | `/interswarm/send` | `Bearer` token with role `admin` or `user` | `JSON { target_agent: str, message: str, user_token: str }` | `types.PostInterswarmSendResponse { response: MAILMessage, events?: list[ServerSentEvent] }` | Sends an outbound interswarm request using an existing user runtime |
+| POST | `/interswarm/send` | `Bearer` token with role `admin` or `user` | `JSON { target_agent: str, message: str, user_token: str, task_id?: str, resume_from?: str, kwargs?: dict }` | `types.PostInterswarmSendResponse { response: MAILMessage, events?: list[ServerSentEvent] }` | Sends an outbound interswarm request using an existing user runtime (same resume semantics as `/message`) |
 | POST | `/swarms/load` | `Bearer` token with role `admin` | `JSON { json: str }` (serialized swarm template) | `types.PostSwarmsLoadResponse { status, swarm_name }` | Replaces the persistent swarm template using a JSON document |
 
 ### SSE streaming
 - `POST /message` with `stream: true` yields a `text/event-stream`
 - **Events** include periodic `ping` heartbeats and terminate with `task_complete` carrying the final serialized response
+- When resuming a task from a breakpoint tool call, provide `resume_from="breakpoint_tool_call"` and include `breakpoint_tool_caller` / `breakpoint_tool_call_result` inside `kwargs`. The runtime appends the tool output to the agent’s history and continues processing until a `task_complete` broadcast is emitted.
 
 ### Error handling
 - FastAPI raises **standard HTTP errors** with a `detail` field
@@ -39,6 +40,7 @@ The server exposes a [FastAPI application](/src/mail/server.py) with endpoints f
 - The server keeps a persistent `MAILSwarmTemplate` catalogue and per-user `MAILSwarm` instances
 - **Message schemas** are documented in [docs/message-format.md](/docs/message-format.md) and [spec/](/spec/SPEC.md)
 - The repository ships an asynchronous helper described in [docs/client.md](/docs/client.md) that wraps these endpoints and handles bearer auth + SSE parsing
+- **Task lifecycle**: Each `POST /message` participates in a long-lived task distinguished by `task_id`. Breakpoint-aware tools can pause a task; clients resume by reusing the same `task_id` with the `resume_from` contract described above. Additional resume modes (such as `user_response`) are reserved for future releases.
 
 ### MAILClient helper
 - `MAILClient` (see [client.md](/docs/client.md)) mirrors every route above with ergonomic async methods

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -42,8 +42,8 @@ Once inside you will see the prompt `mail>`. The REPL accepts any of the subcomm
 | `help` or `?` | Print CLI usage information without exiting the loop. |
 | `exit` / `quit` | Leave the REPL. |
 | `get-health` | Invoke `GET /health` and print the JSON body. |
-| `post-message --message "…" [--entrypoint …] [--show-events]` | Submit a message and print the structured response. |
-| `post-message-stream --message "…"` | Stream SSE events; each event is printed as it arrives. |
+| `post-message --message "…" [--entrypoint …] [--task-id …] [--resume-from …] [--kwargs '{…}'] [--show-events]` | Submit a message and print the structured response. |
+| `post-message-stream --message "…" [--task-id …] [--resume-from …] [--kwargs '{…}']` | Stream SSE events; each event is printed as it arrives. |
 | `get-swarms`, `register-swarm`, `dump-swarm` | Manage the swarm registry. |
 | `send-interswarm-message` | Send interswarm traffic by target agent. |
 | `load-swarm-from-json` | Submit a JSON payload to `POST /swarms/load`. |
@@ -64,6 +64,21 @@ When the server emits events, each `ServerSentEvent` object is printed in
 arrival order. This is particularly useful when you want to monitor `task_complete`
 notifications or inspect intermediate `new_message` / `action_call` events
 without leaving the terminal.
+
+### Working with Tasks and Breakpoint Resumes
+
+- Both messaging commands accept `--task-id`. Provide it to resume an existing task; omit it to let the server allocate one for a brand-new task.
+- To continue a task that paused on a breakpoint tool call, add the following flags:
+
+  ```shell
+  mail> post-message-stream \
+        --task-id weather-123 \
+        --resume-from breakpoint_tool_call \
+        --kwargs '{"breakpoint_tool_caller": "analyst", "breakpoint_tool_call_result": "Forecast: sunny"}'
+  ```
+
+- The `--kwargs` payload must be valid JSON. For breakpoint resumes the runtime requires the two keys shown above; additional fields are ignored by the server unless the runtime exposes more resume hooks in the future.
+- `--resume-from user_response` is reserved for future releases and currently raises an error if supplied.
 
 ## Tips
 - Use the same environment variables you would for the Python client. The CLI simply wraps `MAILClient` and forwards `--url`, `--api-key`, and `--timeout`.

--- a/docs/client.md
+++ b/docs/client.md
@@ -76,6 +76,39 @@ async for event in stream:
 		print("done", event.data)
 ```
 
+## Task Lifecycle and Resuming from Breakpoints
+
+- Every call to `post_message`/`post_message_stream` participates in a **task** identified by `task_id`. If you omit the field, the server generates an ID. Reuse the same `task_id` to continue the conversation (for example, when running the runtime in continuous mode).
+- When an agent invokes a tool that has been marked as a **breakpoint tool**, the runtime pauses the task and waits for the caller to provide the tool result. Resume the task by sending another message with:
+  - The original `task_id`.
+  - `resume_from="breakpoint_tool_call"`.
+  - Extra keyword arguments `breakpoint_tool_caller` (the agent name) and `breakpoint_tool_call_result` (the stringified payload you want appended to the agent history).
+
+```python
+task_id = "weather-task"
+
+# Start a new task (runtime will mark it running until completion or a breakpoint)
+response = await client.post_message(
+	"Plan tomorrow's rehearsal dinner",
+	task_id=task_id,
+	entrypoint="supervisor",
+)
+
+# Later, resume the task after the breakpoint tool returns a value
+stream = await client.post_message_stream(
+	"",
+	task_id=task_id,
+	resume_from="breakpoint_tool_call",
+	breakpoint_tool_caller="analyst",
+	breakpoint_tool_call_result="Forecast: sunny with a high of 75°F",
+)
+async for event in stream:
+	...
+```
+
+- Additional resume styles (for example `resume_from="user_response"`) are reserved for future extensions; attempting to use them currently raises `NotImplementedError`.
+- The runtime automatically resumes the task loop, re-hydrates the agent history with the tool output, and emits the usual `task_complete` event once the agents finish.
+
 ## Error Handling
 - HTTP transport errors raise `RuntimeError` with the originating `aiohttp` exception chained.
 - Non‑JSON responses raise `ValueError` annotated with the returned content type and body.

--- a/mail.toml
+++ b/mail.toml
@@ -10,3 +10,4 @@ registry = "registries/example-no-proxy.json"
 
 [client]
 timeout = 3600.0
+verbose = false

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: MAIL Server API
-  version: "1.0"
+  version: "1.1"
   description: REST API for the Multi-Agent Interface Layer (MAIL) server, including interswarm messaging.
 servers:
   - url: http://localhost:8000
@@ -96,6 +96,15 @@ paths:
                   type: boolean
                   description: When true, server responds with text/event-stream (SSE)
                   default: false
+                resume_from:
+                  type: string
+                  description: When provided, resume the task from the given state
+                  enum: ["user_response", "breakpoint_tool_call"]
+                  default: null
+                kwargs:
+                  type: object
+                  description: Additional keyword arguments to pass to the entrypoint
+                  default: {}
       responses:
         '200':
           description: Final response produced by supervisor after task completion

--- a/src/mail/api.py
+++ b/src/mail/api.py
@@ -610,7 +610,7 @@ class MAILSwarm:
 
     def update_from_adjacency_matrix(self, adj: list[list[int]]) -> None:
         """
-        Update comm_targets for all agents using an adjacency matrix.
+        Update `comm_targets` for all agents using an adjacency matrix.
         """
 
         if len(adj) != len(self.agents):
@@ -633,17 +633,19 @@ class MAILSwarm:
         self,
         body: str,
         subject: str = "New Message",
+        msg_type: Literal["request", "response", "broadcast", "interrupt"] = "request",
         entrypoint: str | None = None,
         show_events: bool = False,
         timeout: float = 3600.0,
     ) -> tuple[MAILMessage, list[ServerSentEvent]]:
         """
         Post a message to the swarm and return the task completion response.
+        This method is indented to be used when the swarm is running in continuous mode.
         """
         if entrypoint is None:
             entrypoint = self.entrypoint
 
-        message = self.build_message(subject, body, [entrypoint], "user", "request")
+        message = self.build_message(subject, body, [entrypoint], "user", msg_type)
 
         return await self.submit_message(message, timeout, show_events)
 
@@ -651,16 +653,18 @@ class MAILSwarm:
         self,
         body: str,
         subject: str = "New Message",
+        msg_type: Literal["request", "response", "broadcast", "interrupt"] = "request",
         entrypoint: str | None = None,
         timeout: float = 3600.0,
     ) -> EventSourceResponse:
         """
         Post a message to the swarm and stream the response.
+        This method is indented to be used when the swarm is running in continuous mode.
         """
         if entrypoint is None:
             entrypoint = self.entrypoint
 
-        message = self.build_message(subject, body, [entrypoint], "user", "request")
+        message = self.build_message(subject, body, [entrypoint], "user", msg_type)
 
         return await self.submit_message_stream(message, timeout)
 
@@ -668,16 +672,18 @@ class MAILSwarm:
         self,
         body: str,
         subject: str = "New Message",
+        msg_type: Literal["request", "response", "broadcast", "interrupt"] = "request",
         entrypoint: str | None = None,
         show_events: bool = False,
     ) -> tuple[MAILMessage, list[ServerSentEvent]]:
         """
-        Post a message to the swarm and run the swarm.
+        Post a message to the swarm and run until the task is complete.
+        This method cannot be used when the swarm is running in continuous mode.
         """
         if entrypoint is None:
             entrypoint = self.entrypoint
 
-        message = self.build_message(subject, body, [entrypoint], "user", "request")
+        message = self.build_message(subject, body, [entrypoint], "user", msg_type)
 
         await self._runtime.submit(message)
         task_response = await self._runtime.run()

--- a/src/mail/api.py
+++ b/src/mail/api.py
@@ -637,6 +637,7 @@ class MAILSwarm:
         entrypoint: str | None = None,
         show_events: bool = False,
         timeout: float = 3600.0,
+        task_id: str | None = None,
     ) -> tuple[MAILMessage, list[ServerSentEvent]]:
         """
         Post a message to the swarm and return the task completion response.
@@ -645,7 +646,7 @@ class MAILSwarm:
         if entrypoint is None:
             entrypoint = self.entrypoint
 
-        message = self.build_message(subject, body, [entrypoint], "user", msg_type)
+        message = self.build_message(subject, body, [entrypoint], "user", msg_type, task_id)
 
         return await self.submit_message(message, timeout, show_events)
 
@@ -655,6 +656,7 @@ class MAILSwarm:
         subject: str = "New Message",
         msg_type: Literal["request", "response", "broadcast", "interrupt"] = "request",
         entrypoint: str | None = None,
+        task_id: str | None = None,
         timeout: float = 3600.0,
     ) -> EventSourceResponse:
         """
@@ -664,7 +666,7 @@ class MAILSwarm:
         if entrypoint is None:
             entrypoint = self.entrypoint
 
-        message = self.build_message(subject, body, [entrypoint], "user", msg_type)
+        message = self.build_message(subject, body, [entrypoint], "user", msg_type, task_id)
 
         return await self.submit_message_stream(message, timeout)
 
@@ -675,6 +677,7 @@ class MAILSwarm:
         msg_type: Literal["request", "response", "broadcast", "interrupt"] = "request",
         entrypoint: str | None = None,
         show_events: bool = False,
+        task_id: str | None = None,
     ) -> tuple[MAILMessage, list[ServerSentEvent]]:
         """
         Post a message to the swarm and run until the task is complete.
@@ -683,7 +686,7 @@ class MAILSwarm:
         if entrypoint is None:
             entrypoint = self.entrypoint
 
-        message = self.build_message(subject, body, [entrypoint], "user", msg_type)
+        message = self.build_message(subject, body, [entrypoint], "user", msg_type, task_id)
 
         await self._runtime.submit(message)
         task_response = await self._runtime.run()
@@ -702,6 +705,7 @@ class MAILSwarm:
         targets: list[str],
         sender_type: Literal["user", "agent"] = "user",
         type: Literal["request", "response", "broadcast", "interrupt"] = "request",
+        task_id: str | None = None,
     ) -> MAILMessage:
         """
         Build a MAIL message.
@@ -715,7 +719,7 @@ class MAILSwarm:
                     id=str(uuid.uuid4()),
                     timestamp=datetime.datetime.now(datetime.UTC).isoformat(),
                     message=MAILRequest(
-                        task_id=str(uuid.uuid4()),
+                        task_id=task_id or str(uuid.uuid4()),
                         request_id=str(uuid.uuid4()),
                         sender=create_user_address(self.user_id)
                         if sender_type == "user"

--- a/src/mail/cli.py
+++ b/src/mail/cli.py
@@ -136,42 +136,49 @@ def main() -> None:
     server_parser = subparsers.add_parser("server", help="start the MAIL server")
     server_parser.set_defaults(func=_run_server_with_args)
     server_parser.add_argument(
+        "-c",
         "--config",
         type=str,
         required=False,
         help="path to the MAIL configuration file",
     )
     server_parser.add_argument(
+        "-p",
         "--port",
         type=int,
         required=False,
         help="port to listen on",
     )
     server_parser.add_argument(
+        "-H",
         "--host",
         type=str,
         required=False,
         help="host to listen on",
     )
     server_parser.add_argument(
+        "-r",
         "--reload",
         type=_str_to_bool,
         required=False,
         help="enable hot reloading",
     )
     server_parser.add_argument(
+        "-n",
         "--swarm-name",
         type=str,
         required=False,
         help="name of the swarm",
     )
     server_parser.add_argument(
+        "-s",
         "--swarm-source",
         type=str,
         required=False,
         help="source of the swarm",
     )
     server_parser.add_argument(
+        "-rf",
         "--swarm-registry",
         type=str,
         required=False,
@@ -182,23 +189,27 @@ def main() -> None:
     client_parser = subparsers.add_parser("client", help="run the MAIL client")
     client_parser.set_defaults(func=_run_client_with_args)
     client_parser.add_argument(
+        "-c",
         "--config",
         type=str,
         required=False,
         help="path to the MAIL configuration file",
     )
     client_parser.add_argument(
+        "-u",
         "--url",
         type=str,
         help="URL of the MAIL server",
     )
     client_parser.add_argument(
+        "-ak",
         "--api-key",
         type=str,
         required=False,
         help="API key for the MAIL server",
     )
     client_parser.add_argument(
+        "-t",
         "--timeout",
         type=float,
         required=False,

--- a/src/mail/cli.py
+++ b/src/mail/cli.py
@@ -100,8 +100,6 @@ def _run_client_with_args(args: argparse.Namespace) -> None:
         if args.timeout is not None:
             client_config.timeout = args.timeout
 
-        print(f"args.verbose: {args.verbose}")
-        print(f"client_config.verbose: {client_config.verbose}")
         if args.verbose:
             client_config.verbose = True
 

--- a/src/mail/cli.py
+++ b/src/mail/cli.py
@@ -100,6 +100,11 @@ def _run_client_with_args(args: argparse.Namespace) -> None:
         if args.timeout is not None:
             client_config.timeout = args.timeout
 
+        print(f"args.verbose: {args.verbose}")
+        print(f"client_config.verbose: {client_config.verbose}")
+        if args.verbose:
+            client_config.verbose = True
+
         client_cli = MAILClientCLI(args, config=client_config)
         asyncio.run(client_cli.run())
     finally:
@@ -214,6 +219,12 @@ def main() -> None:
         type=float,
         required=False,
         help="client request timeout time in seconds",
+    )
+    client_parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="enable verbose output",
     )
 
     # command `version`

--- a/src/mail/client.py
+++ b/src/mail/client.py
@@ -627,7 +627,7 @@ class MAILClientCLI:
         try:
             response = await self.client.post_message(
                 body=args.body,
-                subject=args.subject,
+                subject=args.subject or "New Message",
                 msg_type=args.msg_type,
                 entrypoint=args.entrypoint,
                 show_events=args.show_events,
@@ -644,7 +644,7 @@ class MAILClientCLI:
         try:
             response = await self.client.post_message_stream(
                 body=args.body,
-                subject=args.subject,
+                subject=args.subject or "New Message",
                 msg_type=args.msg_type,
                 entrypoint=args.entrypoint,
                 task_id=args.task_id,

--- a/src/mail/client.py
+++ b/src/mail/client.py
@@ -442,16 +442,37 @@ class MAILClientCLI:
             "post-message", help="send a message to the MAIL server"
         )
         post_message_parser.add_argument(
-            "--message",
+            "-b",
+            "--body",
             type=str,
             help="the message to send",
         )
         post_message_parser.add_argument(
-            "--entrypoint",
+            "-s",
+            "--subject",
             type=str,
-            help="the entrypoint to send the message to",
+            help="the subject of the message",
         )
         post_message_parser.add_argument(
+            "-t",
+            "--msg-type",
+            type=str,
+            help="the type of the message",
+        )
+        post_message_parser.add_argument(
+            "-tid",
+            "--task-id",
+            type=str,
+            help="the task ID of the message",
+        )
+        post_message_parser.add_argument(
+            "-e",
+            "--entrypoint",
+            type=str,
+            help="the agent to send the message to",
+        )
+        post_message_parser.add_argument(
+            "-se",
             "--show-events",
             action="store_true",
             help="show events",
@@ -464,14 +485,34 @@ class MAILClientCLI:
             help="send a message to the MAIL server and stream the response",
         )
         post_message_stream_parser.add_argument(
-            "--message",
+            "-b",
+            "--body",
             type=str,
             help="the message to send",
         )
         post_message_stream_parser.add_argument(
+            "-s",
+            "--subject",
+            type=str,
+            help="the subject of the message",
+        )
+        post_message_stream_parser.add_argument(
+            "-t",
+            "--msg-type",
+            type=str,
+            help="the type of the message",
+        )
+        post_message_stream_parser.add_argument(
+            "-tid",
+            "--task-id",
+            type=str,
+            help="the task ID of the message",
+        )
+        post_message_stream_parser.add_argument(
+            "-e",
             "--entrypoint",
             type=str,
-            help="the entrypoint to send the message to",
+            help="the agent to send the message to",
         )
         post_message_stream_parser.set_defaults(func=self._post_message_stream)
 
@@ -492,22 +533,26 @@ class MAILClientCLI:
             "register-swarm", help="register a swarm with the MAIL server"
         )
         register_swarm_parser.add_argument(
+            "-n",
             "--name",
             type=str,
             help="the name of the swarm",
         )
         register_swarm_parser.add_argument(
+            "-bu",
             "--base-url",
             type=str,
             help="the base URL of the swarm",
         )
         register_swarm_parser.add_argument(
+            "-at",
             "--auth-token",
             type=str,
             required=False,
             help="the auth token of the swarm",
         )
         register_swarm_parser.add_argument(
+            "-v",
             "--volatile",
             type=bool,
             required=False,
@@ -573,7 +618,7 @@ class MAILClientCLI:
         """
         try:
             response = await self.client.post_message(
-                args.message,
+                body=args.body,
                 subject=args.subject,
                 msg_type=args.msg_type,
                 entrypoint=args.entrypoint,
@@ -590,7 +635,7 @@ class MAILClientCLI:
         """
         try:
             response = await self.client.post_message_stream(
-                args.message,
+                body=args.body,
                 subject=args.subject,
                 msg_type=args.msg_type,
                 entrypoint=args.entrypoint,

--- a/src/mail/client.py
+++ b/src/mail/client.py
@@ -165,6 +165,7 @@ class MAILClient:
         *,
         entrypoint: str | None = None,
         show_events: bool = False,
+        task_id: str | None = None,
     ) -> PostMessageResponse:
         """
         Queue a user-scoped task, optionally returning runtime events or an SSE stream (`POST /message`).
@@ -175,6 +176,7 @@ class MAILClient:
             "msg_type": msg_type,
             "entrypoint": entrypoint,
             "show_events": show_events,
+            "task_id": task_id,
         }
 
         return cast(
@@ -189,6 +191,7 @@ class MAILClient:
         msg_type: Literal["request", "response", "broadcast", "interrupt"] = "request",
         *,
         entrypoint: str | None = None,
+        task_id: str | None = None,
     ) -> AsyncIterator[ServerSentEvent]:
         """
         Queue a user-scoped task, optionally returning runtime events or an SSE stream (`POST /message`).
@@ -201,6 +204,7 @@ class MAILClient:
             "msg_type": msg_type,
             "entrypoint": entrypoint,
             "stream": True,
+            "task_id": task_id,
         }
 
         url = self._build_url("/message")
@@ -574,6 +578,7 @@ class MAILClientCLI:
                 msg_type=args.msg_type,
                 entrypoint=args.entrypoint,
                 show_events=args.show_events,
+                task_id=args.task_id,
             )
             print(json.dumps(response, indent=2))
         except Exception as e:
@@ -589,6 +594,7 @@ class MAILClientCLI:
                 subject=args.subject,
                 msg_type=args.msg_type,
                 entrypoint=args.entrypoint,
+                task_id=args.task_id,
             )
             async for event in response:
                 parsed_event = {

--- a/src/mail/client.py
+++ b/src/mail/client.py
@@ -419,7 +419,6 @@ class MAILClientCLI:
         self.args = args
         self._config = config or ClientConfig()
         self.verbose = args.verbose
-        print(f"verbose: {self.verbose}")
         self.client = MAILClient(
             args.url,
             api_key=args.api_key,

--- a/src/mail/config/client.py
+++ b/src/mail/config/client.py
@@ -52,7 +52,10 @@ def _client_defaults() -> dict[str, Any]:
     Resolve client defaults from `mail.toml`, falling back to literals.
     """
 
-    defaults: dict[str, Any] = {"timeout": 3600.0}
+    defaults: dict[str, Any] = {
+        "timeout": 3600.0,
+        "verbose": False,
+    }
 
     if tomllib is None:
         logger.debug("tomllib not available; using built-in client defaults")
@@ -74,9 +77,11 @@ def _client_defaults() -> dict[str, Any]:
     if isinstance(client_section, dict):
         if "timeout" in client_section:
             defaults["timeout"] = float(client_section["timeout"])
-
+        if "verbose" in client_section:
+            defaults["verbose"] = bool(client_section["verbose"])
     return defaults
 
 
 class ClientConfig(BaseModel):
     timeout: float = Field(default_factory=lambda: _client_defaults()["timeout"])
+    verbose: bool = Field(default_factory=lambda: _client_defaults()["verbose"])

--- a/src/mail/core/message.py
+++ b/src/mail/core/message.py
@@ -6,6 +6,8 @@ from typing import Any, Literal, TypedDict
 
 from dict2xml import dict2xml
 
+MAIL_MESSAGE_TYPES = ["request", "response", "broadcast", "interrupt", "broadcast_complete"]
+
 
 class MAILAddress(TypedDict):
     """

--- a/src/mail/core/runtime.py
+++ b/src/mail/core/runtime.py
@@ -6,6 +6,7 @@ import datetime
 import logging
 import uuid
 from asyncio import PriorityQueue, Task
+from collections import defaultdict
 from collections.abc import AsyncGenerator
 from typing import Any
 
@@ -68,9 +69,7 @@ class MAILRuntime:
         self.response_queue: asyncio.Queue[tuple[str, MAILMessage]] = asyncio.Queue()
         self.agents = agents
         self.actions = actions
-        self.agent_histories: dict[str, list[dict[str, Any]]] = {
-            agent: [] for agent in agents
-        }
+        self.agent_histories: dict[str, list[dict[str, Any]]] = defaultdict(list)
         self.active_tasks: set[Task[Any]] = set()
         self.shutdown_event = asyncio.Event()
         self.response_to_user: MAILMessage | None = None
@@ -1173,7 +1172,7 @@ Use this information to decide how to complete your task.""",
                                     )
                                 )
 
-                self.agent_histories[agent_history_key] = history
+                self.agent_histories.setdefault(agent_history_key, [])
             except Exception as e:
                 logger.error(f"error scheduling message for agent '{recipient}': '{e}'")
                 self._submit_event(

--- a/src/mail/core/runtime.py
+++ b/src/mail/core/runtime.py
@@ -40,6 +40,8 @@ from .tools import (
 
 logger = logging.getLogger("mail.runtime")
 
+AGENT_HISTORY_KEY = "{task_id}::{agent_name}"
+
 
 class MAILRuntime:
     """
@@ -904,7 +906,11 @@ Your directly reachable agents can be found in the tool definitions for `send_re
             try:
                 # prepare the message for agent input
                 task_id = message["message"]["task_id"]
-                history = self.agent_histories[recipient]
+
+                # get agent history for this task
+                agent_history_key = AGENT_HISTORY_KEY.format(task_id=task_id, agent_name=recipient)
+                history = self.agent_histories[agent_history_key]
+
                 if not message["message"]["subject"].startswith(
                     "::action_complete_broadcast::"
                 ):
@@ -1167,7 +1173,7 @@ Use this information to decide how to complete your task.""",
                                     )
                                 )
 
-                self.agent_histories[recipient] = history
+                self.agent_histories[agent_history_key] = history
             except Exception as e:
                 logger.error(f"error scheduling message for agent '{recipient}': '{e}'")
                 self._submit_event(

--- a/src/mail/core/tasks.py
+++ b/src/mail/core/tasks.py
@@ -18,6 +18,7 @@ class MAILTask:
         self.task_id = task_id
         self.start_time = datetime.datetime.now(datetime.UTC)
         self.events: list[ServerSentEvent] = []
+        self.is_running = False
     
     def add_event(self, event: ServerSentEvent) -> None:
         """

--- a/src/mail/core/tasks.py
+++ b/src/mail/core/tasks.py
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 Addison Kline
+
+class MAILTask:
+    """
+    A MAIL task.
+    """
+
+    

--- a/src/mail/core/tasks.py
+++ b/src/mail/core/tasks.py
@@ -1,9 +1,104 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2025 Addison Kline
 
+import datetime
+from typing import Literal, cast
+
+from sse_starlette import ServerSentEvent
+
+from mail.core.message import MAILMessage, create_agent_address
+
+
 class MAILTask:
     """
-    A MAIL task.
+    A discrete collection of messages between agents working towards a common goal.
     """
 
+    def __init__(self, task_id: str):
+        self.task_id = task_id
+        self.start_time = datetime.datetime.now(datetime.UTC)
+        self.events: list[ServerSentEvent] = []
     
+    def add_event(self, event: ServerSentEvent) -> None:
+        """
+        Add a new event to the task.
+        """
+        self.events.append(event)
+
+    def get_messages(self) -> list[MAILMessage]:
+        """
+        Get all messages for the task.
+        """
+        messages: list[MAILMessage] = []
+
+        for sse in self.events:
+            if sse.event == "new_message":
+                data = sse.data
+                if data is None:
+                    continue
+                extra_data = data.get("extra_data")
+                if extra_data is None:
+                    continue
+                full_message = extra_data.get("full_message")
+                if full_message is None:
+                    continue
+
+                messages.append(cast(MAILMessage, full_message))
+
+        return messages
+    
+    def get_messages_by_agent(
+        self, 
+        agent: str,
+        sent: bool = True,
+        received: bool = True,
+    ) -> list[MAILMessage]:
+        """
+        Get all messages for a given agent (whether sent or received).
+        """
+        agent_address = create_agent_address(agent)
+
+        sent_messages: list[MAILMessage] = []
+        if sent:
+            sent_messages = [message for message in self.get_messages() if message["message"]["sender"] == agent_address]
+        received_messages: list[MAILMessage] = []
+        if received:
+            for message in self.get_messages():
+                match message["msg_type"]:
+                    case "request" | "response":
+                        if message["message"]["recipient"] == agent_address:  # type: ignore
+                            received_messages.append(message)
+                    case "broadcast" | "interrupt" | "broadcast_complete":
+                        if agent_address in message["message"]["recipients"]:  # type: ignore
+                            received_messages.append(message)
+                    case _:
+                        raise ValueError(f"invalid message type: {message['msg_type']}")
+
+        return sent_messages + received_messages
+
+    def get_messages_by_type(
+        self, 
+        message_type: Literal["request", "response", "broadcast", "interrupt", "broadcast_complete"]
+    ) -> list[MAILMessage]:
+        """
+        Get all messages of a given type.
+        """
+        return [message for message in self.get_messages() if message["msg_type"] == message_type]
+
+    def get_messages_by_system(self) -> list[MAILMessage]:
+        """
+        Get all messages from the system.
+        """
+        return [message for message in self.get_messages() if message["message"]["sender"]["address_type"] == "system"]
+
+    def get_messages_by_user(self) -> list[MAILMessage]:
+        """
+        Get all messages from the user.
+        """
+        return [message for message in self.get_messages() if message["message"]["sender"]["address_type"] == "user"]
+
+    def get_lifetime(self) -> datetime.timedelta:
+        """
+        Get the lifetime of the task.
+        """
+        return datetime.datetime.now(datetime.UTC) - self.start_time

--- a/src/mail/server.py
+++ b/src/mail/server.py
@@ -322,6 +322,7 @@ async def message(request: Request):
         entrypoint: The entrypoint to use for the message.
         show_events: Whether to return the events for the task.
         stream: Whether to stream the response.
+        task_id: The task ID to use for the message.
 
     Returns:
         A dictionary containing the response message.
@@ -352,6 +353,7 @@ async def message(request: Request):
         subject = data.get("subject", "New Message")
         msg_type = data.get("msg_type", "request")
         entrypoint = data.get("entrypoint")
+        task_id = data.get("task_id")
         # Choose recipient: provided entrypoint or default from config
         if isinstance(entrypoint, str) and entrypoint.strip():
             recipient_agent = entrypoint.strip()
@@ -390,6 +392,7 @@ async def message(request: Request):
                 body=body,
                 msg_type=msg_type,
                 entrypoint=chosen_entrypoint,
+                task_id=task_id,
             )
         else:
             logger.info(
@@ -401,6 +404,7 @@ async def message(request: Request):
                 msg_type=msg_type,
                 entrypoint=chosen_entrypoint,
                 show_events=show_events,
+                task_id=task_id,
             )
             # Support both (response, events) and response-only returns
             if isinstance(result, tuple) and len(result) == 2:

--- a/src/mail/server.py
+++ b/src/mail/server.py
@@ -323,6 +323,8 @@ async def message(request: Request):
         show_events: Whether to return the events for the task.
         stream: Whether to stream the response.
         task_id: The task ID to use for the message.
+        resume_from: The type of resume to use for the message.
+        **kwargs: Additional keyword arguments to pass to the runtime.run_task method.
 
     Returns:
         A dictionary containing the response message.
@@ -354,6 +356,8 @@ async def message(request: Request):
         msg_type = data.get("msg_type", "request")
         entrypoint = data.get("entrypoint")
         task_id = data.get("task_id")
+        resume_from = data.get("resume_from", None)
+        kwargs = data.get("kwargs", {})
         # Choose recipient: provided entrypoint or default from config
         if isinstance(entrypoint, str) and entrypoint.strip():
             recipient_agent = entrypoint.strip()
@@ -393,6 +397,8 @@ async def message(request: Request):
                 msg_type=msg_type,
                 entrypoint=chosen_entrypoint,
                 task_id=task_id,
+                resume_from=resume_from,
+                **kwargs,
             )
         else:
             logger.info(
@@ -405,6 +411,8 @@ async def message(request: Request):
                 entrypoint=chosen_entrypoint,
                 show_events=show_events,
                 task_id=task_id,
+                resume_from=resume_from,
+                **kwargs,
             )
             # Support both (response, events) and response-only returns
             if isinstance(result, tuple) and len(result) == 2:

--- a/src/mail/swarms_json/types.py
+++ b/src/mail/swarms_json/types.py
@@ -29,7 +29,8 @@ class SwarmsJSONSwarm(TypedDict):
     """The agents in this swarm."""
     actions: list["SwarmsJSONAction"]
     """The actions in this swarm."""
-
+    breakpoint_tools: list[str]  # default: []
+    """The tools that can be used to breakpoint the swarm."""
 
 class SwarmsJSONAgent(TypedDict):
     """

--- a/src/mail/swarms_json/utils.py
+++ b/src/mail/swarms_json/utils.py
@@ -22,6 +22,8 @@ def load_swarms_json_from_file(path: str) -> SwarmsJSONFile:
             raise ValueError(
                 f"swarms.json file at {path} must contain a list of swarms, actually got {type(contents)}"
             )
+        for swarm in contents:
+            validate_swarm_from_swarms_json(swarm)
         return SwarmsJSONFile(swarms=contents)
 
 
@@ -34,6 +36,8 @@ def load_swarms_json_from_string(contents: str) -> SwarmsJSONFile:
         raise ValueError(
             f"swarms.json string must contain a list of swarms, actually got {type(contents)}"
         )
+    for swarm in contents:
+        validate_swarm_from_swarms_json(swarm)
     return SwarmsJSONFile(swarms=contents)
 
 
@@ -68,6 +72,7 @@ def validate_swarm_from_swarms_json(swarm_candidate: Any) -> None:
 
     OPTIONAL_FIELDS: dict[str, type] = {
         "enable_interswarm": bool,
+        "breakpoint_tools": list,
     }
 
     for field, field_type in REQUIRED_FIELDS.items():
@@ -106,6 +111,7 @@ def build_swarm_from_swarms_json(swarm_candidate: Any) -> SwarmsJSONSwarm:
             for action in swarm_candidate["actions"]
         ],
         enable_interswarm=swarm_candidate.get("enable_interswarm", False),
+        breakpoint_tools=swarm_candidate.get("breakpoint_tools", []),
     )
 
 

--- a/src/mail/utils/logger.py
+++ b/src/mail/utils/logger.py
@@ -40,6 +40,7 @@ def init_logger():
             logging.getLogger(logger).addHandler(file_handler)
 
     # Rich handler for colored console output
+    # All mail loggers should use this handler, except ones that end in 'quiet'
     console_handler = RichHandler(
         rich_tracebacks=True,
         show_time=True,

--- a/src/mail/utils/logger.py
+++ b/src/mail/utils/logger.py
@@ -40,7 +40,8 @@ def init_logger():
             logging.getLogger(logger).addHandler(file_handler)
 
     # Rich handler for colored console output
-    # All mail loggers should use this handler, except ones that end in 'quiet'
+    # All `mail.*` loggers should use this handler
+    # Use `mailquiet.*` for loggers that should not be verbose
     console_handler = RichHandler(
         rich_tracebacks=True,
         show_time=True,

--- a/test-swarm-registry.json
+++ b/test-swarm-registry.json
@@ -1,0 +1,16 @@
+{
+  "local_swarm_name": "example",
+  "local_base_url": "http://localhost:8000",
+  "endpoints": {
+    "example": {
+      "swarm_name": "example",
+      "base_url": "http://localhost:8000",
+      "health_check_url": "http://localhost:8000/health",
+      "auth_token_ref": null,
+      "last_seen": "2025-10-02T20:45:45.109982+00:00",
+      "is_active": true,
+      "metadata": null,
+      "volatile": false
+    }
+  }
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -158,6 +158,14 @@ def patched_server(monkeypatch: pytest.MonkeyPatch):
     server.swarm_mail_instances.clear()
     server.swarm_mail_tasks.clear()
 
+    # required environment variables
+    monkeypatch.setenv("AUTH_ENDPOINT", "http://test-auth.local/login")
+    monkeypatch.setenv("TOKEN_INFO_ENDPOINT", "http://test-auth.local/token-info")
+    monkeypatch.setenv("SWARM_NAME", "example")
+    monkeypatch.setenv("BASE_URL", "http://localhost:8000")
+    monkeypatch.setenv("SWARM_REGISTRY_FILE", "test-swarm-registry.json")
+    monkeypatch.setenv("SWARM_SOURCE", "tests/swarms.json")
+
     # Fake registry prevents network
     monkeypatch.setattr("mail.net.registry.SwarmRegistry", FakeSwarmRegistry)
 

--- a/tests/network/test_server_auth_and_status.py
+++ b/tests/network/test_server_auth_and_status.py
@@ -20,7 +20,10 @@ def test_message_requires_auth_missing_header():
     from mail.server import app
 
     with TestClient(app) as client:
-        r = client.post("/message", json={"message": "Hello"})
+        r = client.post(
+            "/message",
+            json={"subject": "Test", "body": "Hello", "msg_type": "request", "task_id": "test-task-id"},
+        )
         assert r.status_code == 401
         assert r.json()["detail"] in ("no API key provided", "invalid API key format")
 
@@ -36,7 +39,12 @@ def test_message_invalid_auth_format():
         r = client.post(
             "/message",
             headers={"Authorization": "invalid-token"},
-            json={"message": "Hello"},
+            json={
+                "subject": "Test",
+                "body": "Hello",
+                "msg_type": "request",
+                "task_id": "test-task-id",
+            },
         )
         assert r.status_code == 401
         assert r.json()["detail"] == "invalid role"
@@ -59,7 +67,12 @@ def test_message_invalid_role_rejected(monkeypatch: pytest.MonkeyPatch):
         r = client.post(
             "/message",
             headers={"Authorization": "Bearer test-key"},
-            json={"message": "Hello"},
+            json={
+                "subject": "Test",
+                "body": "Hello",
+                "msg_type": "request",
+                "task_id": "test-task-id",
+            },
         )
         assert r.status_code == 401
         assert r.json()["detail"] == "invalid role"
@@ -82,7 +95,12 @@ def test_status_after_message_shows_user_ready_true(monkeypatch: pytest.MonkeyPa
         rc = client.post(
             "/message",
             headers={"Authorization": "Bearer test-key"},
-            json={"message": "Hello"},
+            json={
+                "subject": "Test",
+                "body": "Hello",
+                "msg_type": "request",
+                "task_id": "test-task-id",
+            },
         )
         assert rc.status_code == 200
 

--- a/tests/network/test_server_endpoints.py
+++ b/tests/network/test_server_endpoints.py
@@ -58,7 +58,12 @@ def test_message_flow_success():
         r = client.post(
             "/message",
             headers={"Authorization": "Bearer test-key"},
-            json={"message": "Hello"},
+            json={
+                "subject": "Hello",
+                "body": "Hello",
+                "msg_type": "request",
+                "task_id": "test-task-id",
+            },
         )
         assert r.status_code == 200
         data = r.json()

--- a/tests/network/test_server_endpoints.py
+++ b/tests/network/test_server_endpoints.py
@@ -68,3 +68,26 @@ def test_message_flow_success():
         assert r.status_code == 200
         data = r.json()
         assert data["response"] is not None
+
+
+@pytest.mark.usefixtures("patched_server")
+def test_message_flow_defaults_msg_type_on_none():
+    """
+    The server should treat an explicit `null` message type as a request.
+    """
+    from mail.server import app
+
+    with TestClient(app) as client:
+        r = client.post(
+            "/message",
+            headers={"Authorization": "Bearer test-key"},
+            json={
+                "subject": "Hello",
+                "body": "Hello",
+                "msg_type": None,
+                "task_id": "test-task-id",
+            },
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["response"] is not None

--- a/tests/unit/test_mail_api.py
+++ b/tests/unit/test_mail_api.py
@@ -26,6 +26,7 @@ class FakeMAIL:
         entrypoint: str,
         swarm_registry: Any | None = None,  # noqa: ARG002
         enable_interswarm: bool | None = None,  # noqa: ARG002
+        breakpoint_tools: list[str] | None = None,  # noqa: ARG002
     ) -> None:
         self.agents = agents
         self.actions = actions
@@ -34,6 +35,7 @@ class FakeMAIL:
         self.entrypoint = entrypoint
         self.submitted: list[dict[str, Any]] = []
         self._events: dict[str, list[Any]] = {}
+        self.breakpoint_tools = breakpoint_tools
 
     @pytest.mark.asyncio
     async def submit_and_wait(
@@ -124,6 +126,7 @@ def test_from_swarm_json_valid_creates_swarm() -> None:
         ],
         "actions": [],
         "entrypoint": "supervisor",
+        "breakpoint_tools": [],
     }
 
     tmpl = MAILSwarmTemplate.from_swarm_json(json.dumps(data))
@@ -160,6 +163,7 @@ def test_agent_params_prefixed_python_strings_resolved() -> None:
         ],
         "actions": [],
         "entrypoint": "supervisor",
+        "breakpoint_tools": [],
     }
 
     tmpl = MAILSwarmTemplate.from_swarm_json(json.dumps(data))
@@ -183,6 +187,7 @@ def test_from_swarm_json_missing_required_field_raises(missing: str) -> None:
         "agents": [],
         "actions": [],
         "entrypoint": "supervisor",
+        "breakpoint_tools": [],
     }
     bad = base.copy()
     bad.pop(missing)
@@ -204,6 +209,7 @@ def test_from_swarm_json_wrong_types_raise() -> None:
         "agents": {},
         "actions": {},
         "entrypoint": 999,
+        "breakpoint_tools": "supervisor",
     }
 
     with pytest.raises(ValueError) as exc:
@@ -259,7 +265,9 @@ def test_from_swarm_json_file_selects_named_swarm(tmp_path: Any) -> None:
 
 
 def test_mailagent_to_core_preserves_actions() -> None:
-    """Ensure MAILAgent.to_core retains assigned action permissions."""
+    """
+    Ensure MAILAgent.to_core retains assigned action permissions.
+    """
 
     async def fake_action(_: dict[str, Any]) -> str:
         return "ok"
@@ -424,7 +432,9 @@ async def _stub_action(_: dict[str, Any]) -> str:
 
 
 def test_mailaction_to_pydantic_model_for_tools_enforces_types() -> None:
-    """`MAILAction.to_pydantic_model(for_tools=True)` should enforce declared types."""
+    """
+    `MAILAction.to_pydantic_model(for_tools=True)` should enforce declared types.
+    """
     action = MAILAction(
         name="demo",
         description="Demo action",
@@ -450,7 +460,9 @@ def test_mailaction_to_pydantic_model_for_tools_enforces_types() -> None:
 
 
 def test_mailaction_to_pydantic_model_unsupported_type_raises() -> None:
-    """Unsupported parameter types should raise a ValueError during conversion."""
+    """
+    Unsupported parameter types should raise a ValueError during conversion.
+    """
     action = MAILAction(
         name="bad",
         description="Bad action",
@@ -470,7 +482,9 @@ def test_mailaction_to_pydantic_model_unsupported_type_raises() -> None:
 
 @pytest.mark.parametrize("missing", ["name", "description", "parameters", "function"])
 def test_mailaction_from_swarm_json_missing_required_field(missing: str) -> None:
-    """MAILAction.from_swarm_json should validate presence of required keys."""
+    """
+    MAILAction.from_swarm_json should validate presence of required keys.
+    """
     base = {
         "name": "act",
         "description": "desc",
@@ -486,7 +500,9 @@ def test_mailaction_from_swarm_json_missing_required_field(missing: str) -> None
 
 
 def test_mailaction_from_swarm_json_type_validation() -> None:
-    """MAILAction.from_swarm_json should reject incorrect types."""
+    """
+    AILAction.from_swarm_json should reject incorrect types.
+    """
     bad = {
         "name": 123,
         "description": "desc",

--- a/tests/unit/test_mail_client.py
+++ b/tests/unit/test_mail_client.py
@@ -185,6 +185,8 @@ async def test_mail_client_rest_endpoints() -> None:
         "entrypoint": None,
         "show_events": False,
         "task_id": None,
+        "resume_from": None,
+        "kwargs": {},
     }
     assert captured["messages"][1]["body"] == "needs events"
     assert captured["messages"][1]["subject"] == "New Message"
@@ -192,6 +194,8 @@ async def test_mail_client_rest_endpoints() -> None:
     assert captured["messages"][1]["show_events"] is True
     assert captured["messages"][1]["entrypoint"] == "other"
     assert captured["messages"][1]["task_id"] is None
+    assert captured["messages"][1]["resume_from"] is None
+    assert captured["messages"][1]["kwargs"] == {}
     assert captured["registrations"][0]["volatile"] is False
     assert captured["registrations"][0]["metadata"] == {"label": "alpha"}
     assert captured["interswarm_message"][0]["msg_type"] == "response"
@@ -216,6 +220,8 @@ async def test_mail_client_post_message_stream() -> None:
             "entrypoint": None,
             "stream": True,
             "task_id": None,
+            "resume_from": None,
+            "kwargs": {},
         }
         resp = web.StreamResponse(
             status=200, headers={"Content-Type": "text/event-stream"}

--- a/tests/unit/test_mail_client.py
+++ b/tests/unit/test_mail_client.py
@@ -178,9 +178,20 @@ async def test_mail_client_rest_endpoints() -> None:
         assert dump["status"] == "dumped"
         assert load["status"] == "success"
 
-    assert captured["messages"][0] == {"message": "hello world"}
+    assert captured["messages"][0] == {
+        "subject": "New Message",
+        "body": "hello world",
+        "msg_type": "request",
+        "entrypoint": None,
+        "show_events": False,
+        "task_id": None,
+    }
+    assert captured["messages"][1]["body"] == "needs events"
+    assert captured["messages"][1]["subject"] == "New Message"
+    assert captured["messages"][1]["msg_type"] == "request"
     assert captured["messages"][1]["show_events"] is True
     assert captured["messages"][1]["entrypoint"] == "other"
+    assert captured["messages"][1]["task_id"] is None
     assert captured["registrations"][0]["volatile"] is False
     assert captured["registrations"][0]["metadata"] == {"label": "alpha"}
     assert captured["interswarm_message"][0]["msg_type"] == "response"
@@ -198,7 +209,14 @@ async def test_mail_client_post_message_stream() -> None:
     async def handle_stream(request: web.Request) -> web.StreamResponse:
         assert request.headers.get("Accept") == "text/event-stream"
         payload = await request.json()
-        assert payload["stream"] is True
+        assert payload == {
+            "subject": "New Message",
+            "body": "eventful",
+            "msg_type": "request",
+            "entrypoint": None,
+            "stream": True,
+            "task_id": None,
+        }
         resp = web.StreamResponse(
             status=200, headers={"Content-Type": "text/event-stream"}
         )

--- a/tests/unit/test_mail_client_cli.py
+++ b/tests/unit/test_mail_client_cli.py
@@ -75,7 +75,7 @@ async def test_cli_uses_shlex_for_tokenization(
 
     cli = _make_cli()
 
-    inputs = iter(['post-message --body "hello world"', "exit"])
+    inputs = iter(['post-message "hello world"', "exit"])
 
     def fake_input(_prompt: str) -> str:
         return next(inputs)

--- a/tests/unit/test_mail_client_cli.py
+++ b/tests/unit/test_mail_client_cli.py
@@ -69,13 +69,13 @@ async def test_cli_uses_shlex_for_tokenization(
     captured_messages: list[str] = []
 
     async def fake_post_message(self: MAILClientCLI, args) -> None:  # type: ignore[override]
-        captured_messages.append(args.message)
+        captured_messages.append(args.body)
 
     monkeypatch.setattr(MAILClientCLI, "_post_message", fake_post_message)
 
     cli = _make_cli()
 
-    inputs = iter(['post-message --message "hello world"', "exit"])
+    inputs = iter(['post-message --body "hello world"', "exit"])
 
     def fake_input(_prompt: str) -> str:
         return next(inputs)

--- a/tests/unit/test_mail_client_cli.py
+++ b/tests/unit/test_mail_client_cli.py
@@ -11,7 +11,7 @@ from mail.client import MAILClientCLI
 
 
 def _make_cli() -> MAILClientCLI:
-    args = SimpleNamespace(url="http://example.com", api_key=None)
+    args = SimpleNamespace(url="http://example.com", api_key=None, verbose=False)
     return MAILClientCLI(args)  # type: ignore[arg-type]
 
 

--- a/tests/unit/test_runtime.py
+++ b/tests/unit/test_runtime.py
@@ -20,7 +20,9 @@ from mail.core.runtime import MAILRuntime
 def _make_request(
     task_id: str, sender: str = "supervisor", recipient: str = "analyst"
 ) -> MAILMessage:
-    """Build a minimal MAIL request message for testing."""
+    """
+    Build a minimal MAIL request message for testing.
+    """
     return MAILMessage(
         id=str(uuid.uuid4()),
         timestamp=datetime.datetime.now(datetime.UTC).isoformat(),
@@ -79,8 +81,16 @@ def _make_interrupt(task_id: str) -> MAILMessage:
 
 @pytest.mark.asyncio
 async def test_submit_prioritises_message_types() -> None:
-    """Interrupts and completions should outrank broadcasts, which outrank requests."""
-    runtime = MAILRuntime(agents={}, actions={}, user_id="user-1")
+    """
+    Interrupts and completions should outrank broadcasts, which outrank requests.
+    """
+    runtime = MAILRuntime(
+        agents={},
+        actions={},
+        user_id="user-1",
+        swarm_name="example",
+        entrypoint="supervisor",
+    )
 
     await runtime.submit(_make_request("task-req"))
     await runtime.submit(_make_broadcast("task-bc"))
@@ -107,8 +117,16 @@ async def test_submit_prioritises_message_types() -> None:
 async def test_submit_and_stream_handles_timeout_and_events(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Streaming should emit heartbeats, relay task events, and finish with task_complete."""
-    runtime = MAILRuntime(agents={}, actions={}, user_id="user-2")
+    """
+    Streaming should emit heartbeats, relay task events, and finish with `task_complete`.
+    """
+    runtime = MAILRuntime(
+        agents={},
+        actions={},
+        user_id="user-2",
+        swarm_name="example",
+        entrypoint="supervisor",
+    )
     task_id = "task-stream"
     message = _make_request(task_id)
 
@@ -164,8 +182,16 @@ async def test_submit_and_stream_handles_timeout_and_events(
 
 
 def test_system_broadcast_requires_recipients_for_non_completion() -> None:
-    """Non-task-complete broadcasts must define recipients."""
-    runtime = MAILRuntime(agents={}, actions={}, user_id="user-3")
+    """
+    Non-task-complete broadcasts must define recipients.
+    """
+    runtime = MAILRuntime(
+        agents={},
+        actions={},
+        user_id="user-3",
+        swarm_name="example",
+        entrypoint="supervisor",
+    )
 
     with pytest.raises(ValueError):
         runtime._system_broadcast(
@@ -184,8 +210,16 @@ def test_system_broadcast_requires_recipients_for_non_completion() -> None:
 
 
 def test_submit_event_tracks_events_by_task() -> None:
-    """Events should be stored and filtered per task id."""
-    runtime = MAILRuntime(agents={}, actions={}, user_id="user-4")
+    """
+    Events should be stored and filtered per task id.
+    """
+    runtime = MAILRuntime(
+        agents={},
+        actions={},
+        user_id="user-4",
+        swarm_name="example",
+        entrypoint="supervisor",
+    )
 
     runtime._submit_event("update", "task-a", "first")
     runtime._submit_event("update", "task-b", "second")

--- a/tests/unit/test_runtime.py
+++ b/tests/unit/test_runtime.py
@@ -147,6 +147,7 @@ async def test_submit_and_stream_handles_timeout_and_events(
     ping_event = await agen.__anext__()
     assert ping_event.event == "ping"
 
+    runtime._ensure_task_exists(task_id)
     runtime._submit_event("task_update", task_id, "intermediate status")
 
     update_event = await agen.__anext__()
@@ -220,6 +221,9 @@ def test_submit_event_tracks_events_by_task() -> None:
         swarm_name="example",
         entrypoint="supervisor",
     )
+
+    runtime._ensure_task_exists("task-a")
+    runtime._ensure_task_exists("task-b")
 
     runtime._submit_event("update", "task-a", "first")
     runtime._submit_event("update", "task-b", "second")


### PR DESCRIPTION
- Message posting endpoints now accept an optional values `tast_id: str`, `resume_from: Literal["user_response", "breakpoint_tool_call"]`, and `**kwargs: Any`
- Swarms in `swarms.json` can now have `breakpoint_tools: list[str]` (default = `[]`) that return `task_complete` when reached in the runtime
- User tasks can be resumed from a breakpoint after a tool call by posting a message with params `task_id: {task_to_resume}`, `breakpoint_tool_caller: {tool_calling_agent}`, `breakpoint_tool_call_result: {tool response as str}` and awaiting `task_complete`
- Improved CLIent (`mail.client:MAILClientCLI`): shorthand args, message body as positional argument rather than optional