### PR TITLE
Streaming, custom message types now possible for interswarm messages

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -24,7 +24,7 @@ The server exposes a [FastAPI application](/src/mail/server.py) with endpoints f
 | GET | `/swarms/dump` | `Bearer` token with role `admin` | `None` | `types.GetSwarmsDumpResponse { status, swarm_name }` | Logs the configured persistent swarm and returns acknowledgement |
 | POST | `/interswarm/message` | `Bearer` token with role `agent` | `MAILInterswarmMessage { message_id, source_swarm, target_swarm, payload, ... }` | `MAILMessage` (task response) | Routes an inbound interswarm request into the local runtime and returns the generated response |
 | POST | `/interswarm/response` | `Bearer` token with role `agent` | `MAILMessage { id, msg_type, message }` | `types.PostInterswarmResponseResponse { status, task_id }` | Injects a remote swarm response into the pending task queue |
-| POST | `/interswarm/send` | `Bearer` token with role `admin` or `user` | `JSON { target_agent: str, message: str, user_token: str, task_id?: str, resume_from?: str, kwargs?: dict }` | `types.PostInterswarmSendResponse { response: MAILMessage, events?: list[ServerSentEvent] }` | Sends an outbound interswarm request using an existing user runtime (same resume semantics as `/message`) |
+| POST | `/interswarm/send` | `Bearer` token with role `admin` or `user` | `JSON { user_token: str, message: str, subject?: str, msg_type?: str, target_agent?: str, targets?: list[str], task_id?: str, routing_info?: dict, stream?: bool, ignore_stream_pings?: bool }` | `types.PostInterswarmSendResponse { response: MAILMessage, events?: list[ServerSentEvent] }` | Sends an outbound interswarm message (request or broadcast) using an existing user runtime |
 | POST | `/swarms/load` | `Bearer` token with role `admin` | `JSON { json: str }` (serialized swarm template) | `types.PostSwarmsLoadResponse { status, swarm_name }` | Replaces the persistent swarm template using a JSON document |
 
 ### SSE streaming
@@ -32,6 +32,7 @@ The server exposes a [FastAPI application](/src/mail/server.py) with endpoints f
 - **Events** include periodic `ping` heartbeats and terminate with `task_complete` carrying the final serialized response
 - When resuming a task from a breakpoint tool call, provide `resume_from="breakpoint_tool_call"` and include `breakpoint_tool_caller` / `breakpoint_tool_call_result` inside `kwargs`. The runtime reloads any stashed queue items for that task, appends the tool output to the agent’s history, and continues processing until a `task_complete` broadcast is emitted.
 - To stream interswarm interactions, set `metadata.stream = true` on the `MAILInterswarmMessage`. The receiving swarm will return a `text/event-stream` response; add `metadata.ignore_stream_pings = true` if you prefer to suppress heartbeat `ping` events.
+- `POST /interswarm/send` accepts the same customization flags as local messaging. Use `msg_type="request"` with a single `target_agent`, or `msg_type="broadcast"` with `targets`. Include `stream` / `ignore_stream_pings` to mirror the new interswarm streaming behaviour described above.
 
 ### Error handling
 - FastAPI raises **standard HTTP errors** with a `detail` field

--- a/docs/api.md
+++ b/docs/api.md
@@ -31,6 +31,7 @@ The server exposes a [FastAPI application](/src/mail/server.py) with endpoints f
 - `POST /message` with `stream: true` yields a `text/event-stream`
 - **Events** include periodic `ping` heartbeats and terminate with `task_complete` carrying the final serialized response
 - When resuming a task from a breakpoint tool call, provide `resume_from="breakpoint_tool_call"` and include `breakpoint_tool_caller` / `breakpoint_tool_call_result` inside `kwargs`. The runtime reloads any stashed queue items for that task, appends the tool output to the agent’s history, and continues processing until a `task_complete` broadcast is emitted.
+- To stream interswarm interactions, set `metadata.stream = true` on the `MAILInterswarmMessage`. The receiving swarm will return a `text/event-stream` response; add `metadata.ignore_stream_pings = true` if you prefer to suppress heartbeat `ping` events.
 
 ### Error handling
 - FastAPI raises **standard HTTP errors** with a `detail` field

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,7 +19,7 @@ This section explains the runtime, server, and networking layers that make up a 
 - **Agent histories**: maintained per agent for context and multi-turn behavior
 - **Pending requests**: tracked futures keyed by task_id for correlating final responses and streaming
 - **Events and SSE**: events are collected and streamed via Server-Sent Events (SSE) with heartbeat pings
-- **Interswarm**: optional router that detects `agent@swarm` recipients and routes over HTTP
+- **Interswarm**: optional router that detects `agent@swarm` recipients, routes over HTTP, and can proxy streaming SSE responses from remote swarms when requested
 
 ## Server and API
 - **Persistent template**: built at startup from [swarms.json](/swarms.json) into `MAILSwarmTemplate`

--- a/spec/SPEC.md
+++ b/spec/SPEC.md
@@ -211,14 +211,14 @@ All types are defined in [spec/MAIL-core.schema.json](/spec/MAIL-core.schema.jso
 - **`GET /`**: Server metadata. Returns `{ name, status, version }`.
 - **`GET /health`**: Health probe for interswarm peers. Returns `{ status, swarm_name, timestamp }`.
 - **`GET /status`** (`user|admin`): Server status, including swarm and user-instance indicators.
-- **`POST /message`** (`user|admin`): Body `{ message: string, entrypoint?: string, show_events?: boolean, stream?: boolean, resume_from?: user_response|breakpoint_tool_called, kwargs?: object }`. Creates a MAIL request to the swarm's default entrypoint (or user-specified `entrypoint`) and returns the final `response.body` when `broadcast_complete` resolves. When `stream=true`, the server responds with `text/event-stream` SSE events until completion.
+- **`POST /message`** (`user|admin`): Body `{ body: string, subject?: string, task_id?: string, entrypoint?: string, show_events?: boolean, stream?: boolean, resume_from?: user_response|breakpoint_tool_call, kwargs?: object }`. Creates a MAIL request to the swarm's default entrypoint (or user-specified `entrypoint`) and returns the final `response.body` when `broadcast_complete` resolves. When `stream=true`, the server responds with `text/event-stream` SSE events until completion.
 - **`GET /swarms`**: List known swarms from the registry.
 - **`POST /swarms`** (`admin`): Body `{ name, base_url, auth_token?, volatile?, metadata? }`. Registers or updates a remote swarm. Non-volatile entries persist across restarts.
 - **`GET /swarms/dump`** (`admin`): Logs the active persistent swarm and returns `{ status, swarm_name }`.
 - **`POST /swarms/load`** (`admin`): Body `{ json: string }`. Replaces the persistent swarm definition with the provided JSON payload.
 - **`POST /interswarm/message`** (`agent`): Body is `MAILInterswarmMessage`. Delivers the wrapped payload into local MAIL and returns a `MAILMessage` response for request/response flows.
 - **`POST /interswarm/response`** (`agent`): Body is `MAILMessage`. Submits a remote swarm response back into the origin MAIL pipeline; returns `{ status, task_id }`.
-- **`POST /interswarm/send`** (`user|admin`): Body `{ body: string, message: string, user_token: string }`. Routes a user-initiated interswarm request via the caller's MAIL instance; returns the remote response when available.
+- **`POST /interswarm/send`** (`user|admin`): Body `{ user_token: string, body: string, targets?: string[], subject?: string, msg_type?: request|broadcast, task_id?: string, routing_info?: object, stream?: boolean, ignore_stream_pings?: boolean }`. Callers MUST provide either `message` or `body`, and either `target_agent` (single-recipient request) or `targets` (broadcast). When `stream=true`, the runtime propagates interswarm streaming metadata (`routing_info.stream = true`) and returns `{ response: MAILMessage, events: ServerSentEvent[] | null }`.
 
 ## Swarm Registry
 

--- a/spec/SPEC.md
+++ b/spec/SPEC.md
@@ -1,7 +1,7 @@
 # Multi-Agent Interface Layer (MAIL) — Specification
 
 - **Version**: 1.1
-- **Date**: October 3, 2025
+- **Date**: October 7, 2025
 - **Status**: Open to feedback
 - **Scope**: Defines the data model, addressing, routing semantics, runtime, and REST transport for interoperable communication among autonomous agents within and across swarms.
 - **Authors**: Addison Kline (GitHub: [@addisonkline](https://github.com/addisonkline)), Will Hahn (GitHub: [@wsfhahn](https://github.com/wsfhahn)), Ryan Heaton (GitHub: [@rheaton64](https://github.com/rheaton64)), Jacob Hahn (GitHub: [@jacobtohahn](https://github.com/jacobtohahn))
@@ -218,7 +218,7 @@ All types are defined in [spec/MAIL-core.schema.json](/spec/MAIL-core.schema.jso
 - **`POST /swarms/load`** (`admin`): Body `{ json: string }`. Replaces the persistent swarm definition with the provided JSON payload.
 - **`POST /interswarm/message`** (`agent`): Body is `MAILInterswarmMessage`. Delivers the wrapped payload into local MAIL and returns a `MAILMessage` response for request/response flows.
 - **`POST /interswarm/response`** (`agent`): Body is `MAILMessage`. Submits a remote swarm response back into the origin MAIL pipeline; returns `{ status, task_id }`.
-- **`POST /interswarm/send`** (`user|admin`): Body `{ target_agent: string, message: string, user_token: string }`. Routes a user-initiated interswarm request via the caller's MAIL instance; returns the remote response when available.
+- **`POST /interswarm/send`** (`user|admin`): Body `{ body: string, message: string, user_token: string }`. Routes a user-initiated interswarm request via the caller's MAIL instance; returns the remote response when available.
 
 ## Swarm Registry
 

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -288,24 +288,66 @@ paths:
             schema:
               type: object
               additionalProperties: false
-              required: [target_agent, message, user_token]
+              required: [user_token]
               properties:
-                target_agent: { 
-                  type: string, 
-                  description: "Use agent@swarm format" 
-                }
-                message: { type: string }
-                user_token: { 
-                  type: string, 
-                  description: "User instance key" 
-                }
+                user_token:
+                  type: string
+                  description: User runtime token returned by the `/message` endpoints
+                targets:
+                  type: array
+                  description: Optional list of agent addresses; use when sending broadcasts
+                  items:
+                    type: string
+                body:
+                  type: string
+                  description: Alternative field name for `message`
+                subject:
+                  type: string
+                  description: Subject line for the outgoing MAIL message
+                  default: Interswarm Message
+                msg_type:
+                  type: string
+                  description: MAIL message type to construct
+                  enum: [request, broadcast]
+                  default: request
+                task_id:
+                  type: string
+                  description: Optional task identifier to associate with the message
+                routing_info:
+                  type: object
+                  description: Additional routing metadata appended to the MAIL payload
+                  default: {}
+                stream:
+                  type: boolean
+                  description: Request interswarm streaming for this task
+                ignore_stream_pings:
+                  type: boolean
+                  description: Suppress heartbeat `ping` events when streaming is enabled
+              allOf:
+                - anyOf:
+                    - required: [body]
+                  description: message body must be supplied
+                - anyOf:
+                    - required: [targets]
+                  description: Provide a list of `targets`
       responses:
         '200':
           description: Routed MAIL message result
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MAILMessage'
+                type: object
+                additionalProperties: false
+                properties:
+                  response:
+                    $ref: '#/components/schemas/MAILMessage'
+                  events:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      description: Server-sent event snapshot
+                      additionalProperties: true
         '400':
           description: Bad request
         '401':

--- a/src/mail/api.py
+++ b/src/mail/api.py
@@ -30,6 +30,7 @@ from mail.core.actions import ActionCore
 from mail.core.agents import AgentCore
 from mail.core.tools import MAIL_TOOL_NAMES
 from mail.net import SwarmRegistry
+from mail.net.router import StreamHandler
 from mail.swarms_json import (
     SwarmsJSONAction,
     SwarmsJSONAgent,
@@ -900,7 +901,13 @@ class MAILSwarm:
         """
         return self._runtime.pending_requests
 
-    async def route_interswarm_message(self, message: MAILMessage) -> MAILMessage:
+    async def route_interswarm_message(
+        self,
+        message: MAILMessage,
+        *,
+        stream_handler: StreamHandler | None = None,
+        ignore_stream_pings: bool = False,
+    ) -> MAILMessage:
         """
         Route an interswarm message to the appropriate destination.
         """
@@ -908,7 +915,11 @@ class MAILSwarm:
         if router is None:
             raise ValueError("interswarm router not available")
 
-        return await router.route_message(message)
+        return await router.route_message(
+            message,
+            stream_handler=stream_handler,
+            ignore_stream_pings=ignore_stream_pings,
+        )
 
     def get_subswarm(
         self, names: list[str], name_suffix: str, entrypoint: str | None = None

--- a/src/mail/api.py
+++ b/src/mail/api.py
@@ -860,6 +860,8 @@ class MAILSwarm:
         message: MAILMessage,
         timeout: float = 3600.0,
         resume_from: Literal["user_response", "breakpoint_tool_call"] | None = None,
+        *,
+        ping_interval: int | None = 15000,
         **kwargs: Any,
     ) -> EventSourceResponse:
         """
@@ -878,7 +880,7 @@ class MAILSwarm:
 
         return EventSourceResponse(
             stream,
-            ping=15000,
+            ping=ping_interval,
             headers={
                 "Cache-Control": "no-cache",
                 "Connection": "keep-alive",

--- a/src/mail/client.py
+++ b/src/mail/client.py
@@ -373,10 +373,8 @@ class MAILClient:
 
     async def send_interswarm_message(
         self,
-        target_agent: str | None,
-        message: str,
+        body: str,
         user_token: str,
-        *,
         subject: str | None = None,
         targets: list[str] | None = None,
         msg_type: str | None = None,
@@ -389,12 +387,10 @@ class MAILClient:
         Send an interswarm message to the MAIL server (`POST /interswarm/send`).
         """
         payload: dict[str, Any] = {
-            "message": message,
+            "body": body,
             "user_token": user_token,
         }
 
-        if target_agent is not None:
-            payload["target_agent"] = target_agent
         if targets is not None:
             payload["targets"] = targets
         if subject is not None:
@@ -661,13 +657,13 @@ class MAILClientCLI:
             help="send an interswarm message to the MAIL server",
         )
         send_interswarm_message_parser.add_argument(
-            "--message",
+            "--body",
             type=str,
             help="the message to send",
         )
         send_interswarm_message_parser.add_argument(
-            "--target-agent",
-            type=str,
+            "--targets",
+            type=list[str],
             help="the target agent to send the message to",
         )
         send_interswarm_message_parser.add_argument(
@@ -794,7 +790,7 @@ class MAILClientCLI:
         """
         try:
             response = await self.client.send_interswarm_message(
-                args.target_agent, args.message, args.user_token
+                args.body, args.targets, args.user_token
             )
             print(json.dumps(response, indent=2))
         except Exception as e:

--- a/src/mail/client.py
+++ b/src/mail/client.py
@@ -373,18 +373,42 @@ class MAILClient:
 
     async def send_interswarm_message(
         self,
-        target_agent: str,
+        target_agent: str | None,
         message: str,
         user_token: str,
+        *,
+        subject: str | None = None,
+        targets: list[str] | None = None,
+        msg_type: str | None = None,
+        task_id: str | None = None,
+        routing_info: dict[str, Any] | None = None,
+        stream: bool | None = None,
+        ignore_stream_pings: bool | None = None,
     ) -> PostInterswarmSendResponse:
         """
         Send an interswarm message to the MAIL server (`POST /interswarm/send`).
         """
-        payload = {
-            "target_agent": target_agent,
+        payload: dict[str, Any] = {
             "message": message,
             "user_token": user_token,
         }
+
+        if target_agent is not None:
+            payload["target_agent"] = target_agent
+        if targets is not None:
+            payload["targets"] = targets
+        if subject is not None:
+            payload["subject"] = subject
+        if msg_type is not None:
+            payload["msg_type"] = msg_type
+        if task_id is not None:
+            payload["task_id"] = task_id
+        if routing_info is not None:
+            payload["routing_info"] = routing_info
+        if stream is not None:
+            payload["stream"] = stream
+        if ignore_stream_pings is not None:
+            payload["ignore_stream_pings"] = ignore_stream_pings
 
         return cast(
             PostInterswarmSendResponse,

--- a/src/mail/net/registry.py
+++ b/src/mail/net/registry.py
@@ -61,7 +61,7 @@ class SwarmRegistry:
             volatile=False,  # Local swarm is never volatile
         )
         logger.info(
-            f"registered local swarm: '{self.local_swarm_name}' at '{base_url}'"
+            f"registered local swarm: '{self.local_swarm_name}' at {base_url}"
         )
 
     def register_swarm(
@@ -98,7 +98,7 @@ class SwarmRegistry:
             volatile=volatile,
         )
         logger.info(
-            f"registered remote swarm: '{swarm_name}' at '{base_url}' (volatile: '{volatile}')"
+            f"registered remote swarm: '{swarm_name}' at {base_url} (volatile: '{volatile}')"
         )
 
         # Save persistent endpoints if this swarm is non-volatile

--- a/src/mail/server.py
+++ b/src/mail/server.py
@@ -136,16 +136,14 @@ async def _server_startup() -> None:
         raise e
 
     # ensure necessary auth endpoints are registered
-    auth_endpoints = ["AUTH_ENDPOINT", "TOKEN_INFO_ENDPOINT"]
-    for endpoint in auth_endpoints:
-        if endpoint not in os.environ:
-            logger.error(f"required environment variable '{endpoint}' is not set")
-            raise Exception(f"required environment variable '{endpoint}' is not set")
+    await utils.auth.check_auth_endpoints()
+    logger.info(f"endpoint 'AUTH_ENDPOINT' = {os.getenv('AUTH_ENDPOINT')}")
+    logger.info(f"endpoint 'TOKEN_INFO_ENDPOINT' = {os.getenv('TOKEN_INFO_ENDPOINT')}")
 
     # ensure necessary swarm endpoints are registered
     swarm_endpoints = ["SWARM_REGISTRY_FILE", "SWARM_SOURCE"]
     for endpoint in swarm_endpoints:
-        if endpoint not in os.environ:
+        if endpoint not in os.environ or os.getenv(endpoint) is None:
             logger.error(f"required environment variable '{endpoint}' is not set")
             raise Exception(f"required environment variable '{endpoint}' is not set")
 

--- a/src/mail/server.py
+++ b/src/mail/server.py
@@ -745,9 +745,8 @@ async def send_interswarm_message(request: Request):
     Intended for users and admins.
 
     Args:
-        target_agent: The target agent to send the message to.
         targets: The targets to send the message to.
-        message: The message to send.
+        body: The message to send.
         subject: The subject of the message.
         msg_type: The type of the message.
         task_id: The task ID of the message.
@@ -769,9 +768,8 @@ async def send_interswarm_message(request: Request):
 
         # parse request
         data = await request.json()
-        target_agent = data.get("target_agent")
         targets = data.get("targets")
-        message_content = data.get("message") or data.get("body")
+        message_content = data.get("body")
         subject = data.get("subject", "Interswarm Message")
         msg_type = data.get("msg_type", "request")
         task_id = data.get("task_id") or str(uuid.uuid4())
@@ -787,11 +785,6 @@ async def send_interswarm_message(request: Request):
 
         user_token = data.get("user_token")
 
-        if targets is None:
-            targets = [target_agent] if target_agent else []
-
-        targets = [t for t in targets if t]
-
         if message_content is not None and not isinstance(message_content, str):
             message_content = str(message_content)
 
@@ -801,7 +794,7 @@ async def send_interswarm_message(request: Request):
         if not targets or not message_content:
             raise HTTPException(
                 status_code=400,
-                detail="'targets' (or 'target_agent') and 'message' are required",
+                detail="'targets' and 'body' are required",
             )
 
         if not user_token or user_token not in user_mail_instances:

--- a/tests/network/test_interswarm_endpoints.py
+++ b/tests/network/test_interswarm_endpoints.py
@@ -282,8 +282,8 @@ def test_interswarm_send_custom_request(monkeypatch: pytest.MonkeyPatch):
 
     with TestClient(app) as client:
         payload = {
-            "target_agent": "helper@remote",
-            "message": "Hello remote",
+            "targets": ["helper@remote"],
+            "body": "Hello remote",
             "subject": "Custom Subject",
             "msg_type": "request",
             "task_id": "task-xyz",
@@ -342,7 +342,7 @@ def test_interswarm_send_broadcast(monkeypatch: pytest.MonkeyPatch):
     with TestClient(app) as client:
         payload = {
             "targets": ["helper@remote", "analyst"],
-            "message": "Broadcast body",
+            "body": "Broadcast body",
             "subject": "Broadcast",
             "msg_type": "broadcast",
             "user_token": "token-broadcast",
@@ -388,8 +388,8 @@ def test_interswarm_send_invalid_msg_type(monkeypatch: pytest.MonkeyPatch):
 
     with TestClient(app) as client:
         payload = {
-            "target_agent": "helper@remote",
-            "message": "Body",
+            "targets": ["helper@remote"],
+            "body": "Body",
             "msg_type": "interrupt",
             "user_token": "token-invalid",
         }

--- a/tests/unit/test_mail_client.py
+++ b/tests/unit/test_mail_client.py
@@ -167,7 +167,7 @@ async def test_mail_client_rest_endpoints() -> None:
             await client.post_interswarm_message(EXAMPLE_INTERSWARM_MESSAGE)  # type: ignore[arg-type]
             await client.post_interswarm_response(EXAMPLE_MAIL_MESSAGE)  # type: ignore[arg-type]
             await client.send_interswarm_message(
-                "agent@remote", "hello", user_token="demo-user"
+                "hello", targets=["agent@remote"], user_token="demo-user"
             )
             load = await client.load_swarm_from_json("{}")
 
@@ -200,8 +200,8 @@ async def test_mail_client_rest_endpoints() -> None:
     assert captured["registrations"][0]["metadata"] == {"label": "alpha"}
     assert captured["interswarm_message"][0]["msg_type"] == "response"
     assert captured["interswarm_response"][0]["msg_type"] == "response"
-    assert captured["interswarm_send"][0]["target_agent"] == "agent@remote"
-    assert captured["interswarm_send"][0]["message"] == "hello"
+    assert captured["interswarm_send"][0]["targets"] == ["agent@remote"]
+    assert captured["interswarm_send"][0]["body"] == "hello"
     assert captured["interswarm_send"][0]["user_token"] == "demo-user"
     assert captured["swarm_load"][0]["json"] == "{}"
 


### PR DESCRIPTION
- Interswarm messages can now stream SSEs back to the calling swarm if `metadata` contains the field `stream = True`
- Setting the `metadata` field `ignore_stream_pings = True` will suppress pings from the event stream
- Endpoint `POST /interswarm/send` now allows for the user to specify message `body`, `subject`, `targets`, `msg_type` (either `request` or `broadcast`), and streaming config
- Updated docs and tests accordingly; all tests pass