### PR TITLE
Interswarm streaming; improvements to `POST /interswarm/send`; new endpoint `GET /whoami`; improved CLI

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -17,6 +17,7 @@ The server exposes a [FastAPI application](/src/mail/server.py) with endpoints f
 | --- | --- | --- | --- | --- | --- |
 | GET | `/` | None (public) | `None` | `types.GetRootResponse { name, status, version }` | Returns MAIL service metadata and version string |
 | GET | `/status` | `Bearer` token with role `admin` or `user` | `None` | `types.GetStatusResponse { swarm, active_users, user_mail_ready, user_task_running }` | Reports persistent swarm readiness and whether the caller already has a running runtime |
+| GET | `/whoami` | `Bearer` token with role `admin` or `user` | `None` | `types.GetWhoamiResponse { username, role }` | Returns the username and role associated with the provided token |
 | POST | `/message` | `Bearer` token with role `admin` or `user` | `JSON { subject: str, body: str, msg_type?: str, entrypoint?: str, show_events?: bool, stream?: bool, task_id?: str, resume_from?: str, kwargs?: dict }` | `types.PostMessageResponse { response: str, events?: list[ServerSentEvent] }` (or `text/event-stream` when `stream: true`) | Queues or resumes a user-scoped task; supports breakpoint resumes via `resume_from="breakpoint_tool_call"` and extra kwargs |
 | GET | `/health` | None (public) | `None` | `types.GetHealthResponse { status, swarm_name, timestamp }` | Liveness signal used for interswarm discovery |
 | GET | `/swarms` | None (public) | `None` | `types.GetSwarmsResponse { swarms: list[types.SwarmEndpoint] }` | Lists swarms known to the local registry |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,7 +19,7 @@ This section explains the runtime, server, and networking layers that make up a 
 - **Agent histories**: maintained per agent for context and multi-turn behavior
 - **Pending requests**: tracked futures keyed by task_id for correlating final responses and streaming
 - **Events and SSE**: events are collected and streamed via Server-Sent Events (SSE) with heartbeat pings
-- **Interswarm**: optional router that detects `agent@swarm` recipients and routes over HTTP
+- **Interswarm**: optional router that detects `agent@swarm` recipients, routes over HTTP, and can proxy streaming SSE responses from remote swarms when requested
 
 ## Server and API
 - **Persistent template**: built at startup from [swarms.json](/swarms.json) into `MAILSwarmTemplate`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -42,6 +42,7 @@ Once inside you will see the prompt `mail>`. The REPL accepts any of the subcomm
 | `help` or `?` | Print CLI usage information without exiting the loop. |
 | `exit` / `quit` | Leave the REPL. |
 | `get-health` | Invoke `GET /health` and print the JSON body. |
+| `get-whoami` | Invoke `GET /whoami` and display the caller's username and role. |
 | `post-message --message "…" [--entrypoint …] [--task-id …] [--resume-from …] [--kwargs '{…}'] [--show-events]` | Submit a message and print the structured response. |
 | `post-message-stream --message "…" [--task-id …] [--resume-from …] [--kwargs '{…}']` | Stream SSE events; each event is printed as it arrives. |
 | `get-swarms`, `register-swarm`, `dump-swarm` | Manage the swarm registry. |

--- a/docs/client.md
+++ b/docs/client.md
@@ -58,6 +58,7 @@ The class implements `__aenter__` / `__aexit__`, so `async with` automatically o
 | Category | Methods | Notes |
 | --- | --- | --- |
 | Service metadata | `get_root()`, `get_status()` | Mirrors `GET /` and `GET /status`. |
+| Identity | `get_whoami()` | Fetches the caller's username and role via `GET /whoami`. |
 | Health | `get_health()` | Returns interswarm readiness info. |
 | Messaging | `post_message(message, entrypoint=None, show_events=False)`, `post_message_stream(message, entrypoint=None)` | Handles synchronous responses and SSE streaming. |
 | Swarm registry | `get_swarms()`, `register_swarm(...)`, `dump_swarm()`, `load_swarm_from_json(json_str)` | Manage remote swarm entries and persistent templates. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -77,6 +77,7 @@ timeout = 3600.0
                 "name": "math",
                 "factory": "mail.examples.math_dummy.agent:factory_math_dummy",
                 "comm_targets": ["supervisor", "weather"],
+                "actions": ["calculate_expression"],
                 "agent_params": {
                     "llm": "openai/gpt-5-mini",
                     "system": "mail.examples.math_dummy.prompts:SYSPROMPT"
@@ -96,6 +97,19 @@ timeout = 3600.0
                     }
                 },
                 "function": "mail.examples.weather_dummy.actions:get_weather_forecast"
+            },
+            {
+                "name": "calculate_expression",
+                "description": "Evaluate a basic arithmetic expression inside the math agent",
+                "parameters": { 
+                    "type": "object",
+                    "properties": {
+                        "expression": { "type": "string", "description": "Expression to evaluate" },
+                        "precision": { "type": "integer", "minimum": 0, "maximum": 12, "description": "Optional number of decimal places" }
+                    },
+                    "required": ["expression"]
+                },
+                "function": "mail.examples.math_dummy.actions:calculate_expression"
             }
         ]
     }

--- a/spec/SPEC.md
+++ b/spec/SPEC.md
@@ -1,6 +1,6 @@
 # Multi-Agent Interface Layer (MAIL) — Specification
 
-- **Version**: 1.1
+- **Version**: 1.1-pre2
 - **Date**: October 7, 2025
 - **Status**: Open to feedback
 - **Scope**: Defines the data model, addressing, routing semantics, runtime, and REST transport for interoperable communication among autonomous agents within and across swarms.
@@ -254,7 +254,7 @@ All types are defined in [spec/MAIL-core.schema.json](/spec/MAIL-core.schema.jso
 
 ## Versioning
 
-- **Protocol version**: 1.1
+- **Protocol version**: 1.1-pre2
 - Backward-incompatible changes MUST bump the minor (or major) version and update OpenAPI `info.version`.
 
 ## References

--- a/spec/SPEC.md
+++ b/spec/SPEC.md
@@ -203,7 +203,7 @@ All types are defined in [spec/MAIL-core.schema.json](/spec/MAIL-core.schema.jso
 - HTTP Bearer[^rfc6750] authentication.
 - **Roles**:
   - `agent`: may call `/interswarm/message`, `/interswarm/response`.
-  - `user`: may call `/status`, `/message`, `/swarms`, `/interswarm/send`.
+  - `user`: may call `/status`, `/whoami`, `/message`, `/swarms`, `/interswarm/send`.
   - `admin`: inherits `user` access and may additionally call `/swarms` (POST), `/swarms/dump`, `/swarms/load`.
 
 ### Endpoints
@@ -211,6 +211,7 @@ All types are defined in [spec/MAIL-core.schema.json](/spec/MAIL-core.schema.jso
 - **`GET /`**: Server metadata. Returns `{ name, status, version }`.
 - **`GET /health`**: Health probe for interswarm peers. Returns `{ status, swarm_name, timestamp }`.
 - **`GET /status`** (`user|admin`): Server status, including swarm and user-instance indicators.
+- **`GET /whoami`** (`user|admin`): Returns `{ username, role }` derived from the presented token. Useful for clients to confirm identity/role assignments.
 - **`POST /message`** (`user|admin`): Body `{ body: string, subject?: string, task_id?: string, entrypoint?: string, show_events?: boolean, stream?: boolean, resume_from?: user_response|breakpoint_tool_call, kwargs?: object }`. Creates a MAIL request to the swarm's default entrypoint (or user-specified `entrypoint`) and returns the final `response.body` when `broadcast_complete` resolves. When `stream=true`, the server responds with `text/event-stream` SSE events until completion.
 - **`GET /swarms`**: List known swarms from the registry.
 - **`POST /swarms`** (`admin`): Body `{ name, base_url, auth_token?, volatile?, metadata? }`. Registers or updates a remote swarm. Non-volatile entries persist across restarts.

--- a/spec/SPEC.md
+++ b/spec/SPEC.md
@@ -1,7 +1,7 @@
 # Multi-Agent Interface Layer (MAIL) — Specification
 
 - **Version**: 1.1
-- **Date**: October 3, 2025
+- **Date**: October 7, 2025
 - **Status**: Open to feedback
 - **Scope**: Defines the data model, addressing, routing semantics, runtime, and REST transport for interoperable communication among autonomous agents within and across swarms.
 - **Authors**: Addison Kline (GitHub: [@addisonkline](https://github.com/addisonkline)), Will Hahn (GitHub: [@wsfhahn](https://github.com/wsfhahn)), Ryan Heaton (GitHub: [@rheaton64](https://github.com/rheaton64)), Jacob Hahn (GitHub: [@jacobtohahn](https://github.com/jacobtohahn))
@@ -211,14 +211,14 @@ All types are defined in [spec/MAIL-core.schema.json](/spec/MAIL-core.schema.jso
 - **`GET /`**: Server metadata. Returns `{ name, status, version }`.
 - **`GET /health`**: Health probe for interswarm peers. Returns `{ status, swarm_name, timestamp }`.
 - **`GET /status`** (`user|admin`): Server status, including swarm and user-instance indicators.
-- **`POST /message`** (`user|admin`): Body `{ message: string, entrypoint?: string, show_events?: boolean, stream?: boolean, resume_from?: user_response|breakpoint_tool_called, kwargs?: object }`. Creates a MAIL request to the swarm's default entrypoint (or user-specified `entrypoint`) and returns the final `response.body` when `broadcast_complete` resolves. When `stream=true`, the server responds with `text/event-stream` SSE events until completion.
+- **`POST /message`** (`user|admin`): Body `{ body: string, subject?: string, task_id?: string, entrypoint?: string, show_events?: boolean, stream?: boolean, resume_from?: user_response|breakpoint_tool_call, kwargs?: object }`. Creates a MAIL request to the swarm's default entrypoint (or user-specified `entrypoint`) and returns the final `response.body` when `broadcast_complete` resolves. When `stream=true`, the server responds with `text/event-stream` SSE events until completion.
 - **`GET /swarms`**: List known swarms from the registry.
 - **`POST /swarms`** (`admin`): Body `{ name, base_url, auth_token?, volatile?, metadata? }`. Registers or updates a remote swarm. Non-volatile entries persist across restarts.
 - **`GET /swarms/dump`** (`admin`): Logs the active persistent swarm and returns `{ status, swarm_name }`.
 - **`POST /swarms/load`** (`admin`): Body `{ json: string }`. Replaces the persistent swarm definition with the provided JSON payload.
 - **`POST /interswarm/message`** (`agent`): Body is `MAILInterswarmMessage`. Delivers the wrapped payload into local MAIL and returns a `MAILMessage` response for request/response flows.
 - **`POST /interswarm/response`** (`agent`): Body is `MAILMessage`. Submits a remote swarm response back into the origin MAIL pipeline; returns `{ status, task_id }`.
-- **`POST /interswarm/send`** (`user|admin`): Body `{ target_agent: string, message: string, user_token: string }`. Routes a user-initiated interswarm request via the caller's MAIL instance; returns the remote response when available.
+- **`POST /interswarm/send`** (`user|admin`): Body `{ user_token: string, body: string, targets?: string[], subject?: string, msg_type?: request|broadcast, task_id?: string, routing_info?: object, stream?: boolean, ignore_stream_pings?: boolean }`. Callers MUST provide either `message` or `body`, and either `target_agent` (single-recipient request) or `targets` (broadcast). When `stream=true`, the runtime propagates interswarm streaming metadata (`routing_info.stream = true`) and returns `{ response: MAILMessage, events: ServerSentEvent[] | null }`.
 
 ## Swarm Registry
 

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -288,24 +288,66 @@ paths:
             schema:
               type: object
               additionalProperties: false
-              required: [target_agent, message, user_token]
+              required: [user_token]
               properties:
-                target_agent: { 
-                  type: string, 
-                  description: "Use agent@swarm format" 
-                }
-                message: { type: string }
-                user_token: { 
-                  type: string, 
-                  description: "User instance key" 
-                }
+                user_token:
+                  type: string
+                  description: User runtime token returned by the `/message` endpoints
+                targets:
+                  type: array
+                  description: Optional list of agent addresses; use when sending broadcasts
+                  items:
+                    type: string
+                body:
+                  type: string
+                  description: Alternative field name for `message`
+                subject:
+                  type: string
+                  description: Subject line for the outgoing MAIL message
+                  default: Interswarm Message
+                msg_type:
+                  type: string
+                  description: MAIL message type to construct
+                  enum: [request, broadcast]
+                  default: request
+                task_id:
+                  type: string
+                  description: Optional task identifier to associate with the message
+                routing_info:
+                  type: object
+                  description: Additional routing metadata appended to the MAIL payload
+                  default: {}
+                stream:
+                  type: boolean
+                  description: Request interswarm streaming for this task
+                ignore_stream_pings:
+                  type: boolean
+                  description: Suppress heartbeat `ping` events when streaming is enabled
+              allOf:
+                - anyOf:
+                    - required: [body]
+                  description: message body must be supplied
+                - anyOf:
+                    - required: [targets]
+                  description: Provide a list of `targets`
       responses:
         '200':
           description: Routed MAIL message result
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MAILMessage'
+                type: object
+                additionalProperties: false
+                properties:
+                  response:
+                    $ref: '#/components/schemas/MAILMessage'
+                  events:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      description: Server-sent event snapshot
+                      additionalProperties: true
         '400':
           description: Bad request
         '401':

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -68,6 +68,26 @@ paths:
                   active_users: { type: integer }
                   user_mail_ready: { type: boolean }
                   user_task_running: { type: boolean }
+  /whoami:
+    get:
+      summary: Caller identity
+      operationId: whoami
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Username and role bound to the supplied token
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+                required: [username, role]
+                properties:
+                  username: { type: string }
+                  role: { type: string }
+        '401':
+          description: Unauthorized
   /message:
     post:
       summary: Send a message to the swarm 

--- a/src/mail/api.py
+++ b/src/mail/api.py
@@ -30,6 +30,7 @@ from mail.core.actions import ActionCore
 from mail.core.agents import AgentCore
 from mail.core.tools import MAIL_TOOL_NAMES
 from mail.net import SwarmRegistry
+from mail.net.router import StreamHandler
 from mail.swarms_json import (
     SwarmsJSONAction,
     SwarmsJSONAgent,
@@ -860,6 +861,8 @@ class MAILSwarm:
         message: MAILMessage,
         timeout: float = 3600.0,
         resume_from: Literal["user_response", "breakpoint_tool_call"] | None = None,
+        *,
+        ping_interval: int | None = 15000,
         **kwargs: Any,
     ) -> EventSourceResponse:
         """
@@ -878,7 +881,7 @@ class MAILSwarm:
 
         return EventSourceResponse(
             stream,
-            ping=15000,
+            ping=ping_interval,
             headers={
                 "Cache-Control": "no-cache",
                 "Connection": "keep-alive",
@@ -898,7 +901,13 @@ class MAILSwarm:
         """
         return self._runtime.pending_requests
 
-    async def route_interswarm_message(self, message: MAILMessage) -> MAILMessage:
+    async def route_interswarm_message(
+        self,
+        message: MAILMessage,
+        *,
+        stream_handler: StreamHandler | None = None,
+        ignore_stream_pings: bool = False,
+    ) -> MAILMessage:
         """
         Route an interswarm message to the appropriate destination.
         """
@@ -906,7 +915,11 @@ class MAILSwarm:
         if router is None:
             raise ValueError("interswarm router not available")
 
-        return await router.route_message(message)
+        return await router.route_message(
+            message,
+            stream_handler=stream_handler,
+            ignore_stream_pings=ignore_stream_pings,
+        )
 
     def get_subswarm(
         self, names: list[str], name_suffix: str, entrypoint: str | None = None

--- a/src/mail/api.py
+++ b/src/mail/api.py
@@ -162,12 +162,6 @@ class MAILAgentTemplate:
             raise ValueError(
                 f"agent name must be at least 1 character long, got {len(self.name)}"
             )
-        if len(self.comm_targets) < 1 and (
-            self.can_complete_tasks is False or self.enable_entrypoint is False
-        ):
-            raise ValueError(
-                f"agent must have at least one communication target, got {len(self.comm_targets)}. If should be a solo agent, set can_complete_tasks and enable_entrypoint to True."
-            )
 
     def _top_level_params(self) -> dict[str, Any]:
         return {

--- a/src/mail/client.py
+++ b/src/mail/client.py
@@ -949,12 +949,6 @@ class MAILClientCLI:
                         candidate = candidate.replace("\\n", "").replace("\\t", "\t").replace("[\\'", "").replace("\\']", "")
                         collected_set.add(candidate)
                 return
-            if hasattr(node, "data"):
-                try:
-                    _walk(getattr(node, "data"))
-                except Exception:
-                    pass
-                return
             if hasattr(node, "description"):
                 try:
                     _walk(getattr(node, "description"))

--- a/src/mail/client.py
+++ b/src/mail/client.py
@@ -373,18 +373,38 @@ class MAILClient:
 
     async def send_interswarm_message(
         self,
-        target_agent: str,
-        message: str,
+        body: str,
         user_token: str,
+        subject: str | None = None,
+        targets: list[str] | None = None,
+        msg_type: str | None = None,
+        task_id: str | None = None,
+        routing_info: dict[str, Any] | None = None,
+        stream: bool | None = None,
+        ignore_stream_pings: bool | None = None,
     ) -> PostInterswarmSendResponse:
         """
         Send an interswarm message to the MAIL server (`POST /interswarm/send`).
         """
-        payload = {
-            "target_agent": target_agent,
-            "message": message,
+        payload: dict[str, Any] = {
+            "body": body,
             "user_token": user_token,
         }
+
+        if targets is not None:
+            payload["targets"] = targets
+        if subject is not None:
+            payload["subject"] = subject
+        if msg_type is not None:
+            payload["msg_type"] = msg_type
+        if task_id is not None:
+            payload["task_id"] = task_id
+        if routing_info is not None:
+            payload["routing_info"] = routing_info
+        if stream is not None:
+            payload["stream"] = stream
+        if ignore_stream_pings is not None:
+            payload["ignore_stream_pings"] = ignore_stream_pings
 
         return cast(
             PostInterswarmSendResponse,
@@ -637,13 +657,13 @@ class MAILClientCLI:
             help="send an interswarm message to the MAIL server",
         )
         send_interswarm_message_parser.add_argument(
-            "--message",
+            "--body",
             type=str,
             help="the message to send",
         )
         send_interswarm_message_parser.add_argument(
-            "--target-agent",
-            type=str,
+            "--targets",
+            type=list[str],
             help="the target agent to send the message to",
         )
         send_interswarm_message_parser.add_argument(
@@ -770,7 +790,7 @@ class MAILClientCLI:
         """
         try:
             response = await self.client.send_interswarm_message(
-                args.target_agent, args.message, args.user_token
+                args.body, args.targets, args.user_token
             )
             print(json.dumps(response, indent=2))
         except Exception as e:

--- a/src/mail/client.py
+++ b/src/mail/client.py
@@ -872,14 +872,16 @@ class MAILClientCLI:
         if attempt_login:
             try:
                 whoami = await self.client.get_whoami()
-                self.username = whoami["username"]
-                self.base_url = self.client.base_url
             except Exception as e:
-                self.client._console.print(f"[red bold]error[/red bold] logging into swarm: {e}")
-                return
+                self.client._console.print(
+                    f"[yellow]warning[/yellow]: unable to determine identity via /whoami ({e}). Continuing as anonymous."
+                )
+                self.username = "unknown"
+            else:
+                self.username = whoami.get("username", "unknown")
         else:
             self.username = "unknown"
-            self.base_url = self.client.base_url
+        self.base_url = self.client.base_url
 
         self._print_preamble()
 

--- a/src/mail/core/runtime.py
+++ b/src/mail/core/runtime.py
@@ -1141,7 +1141,7 @@ If your assigned task cannot be completed, inform your caller of this error and 
                             sender_agent,
                             self._system_response(
                                 task_id=message["message"]["task_id"],
-                                recipient=create_agent_address(recipient),
+                                recipient=create_agent_address(sender_agent),
                                 subject="Improper response to user",
                                 body=f"""The user ('{self.user_id}') is unable to respond to your message. 
 If the user's task is complete, use the 'task_complete' tool.
@@ -1178,7 +1178,7 @@ In order to prevent infinite loops, system-to-system messages immediately end th
                             sender_agent,
                             self._system_response(
                                 task_id=message["message"]["task_id"],
-                                recipient=create_agent_address(recipient),
+                                recipient=create_agent_address(sender_agent),
                                 subject=f"Unknown Agent: '{recipient_agent}'",
                                 body=f"""The agent '{recipient_agent}' is not known to this swarm.
 Your directly reachable agents can be found in the tool definitions for `send_request` and `send_response`.""",

--- a/src/mail/core/runtime.py
+++ b/src/mail/core/runtime.py
@@ -899,6 +899,8 @@ It is impossible to resume a task without `{kwarg}` specified.""",
             has_interswarm_recipients = False
 
             if "recipients" in msg_content:
+                if msg_content["recipients"] == MAIL_ALL_LOCAL_AGENTS: # type: ignore
+                    msg_content["recipients"] = list(self.agents.keys()) # type: ignore
                 for recipient in msg_content["recipients"]:  # type: ignore
                     _, recipient_swarm = parse_agent_address(recipient["address"])
                     if recipient_swarm and recipient_swarm != self.swarm_name:
@@ -1142,8 +1144,6 @@ If your assigned task cannot be completed, inform your caller of this error and 
             # Only process if this is a local agent or no swarm specified
             if not recipient_swarm or recipient_swarm == self.swarm_name:
                 if recipient_agent in self.agents:
-                    self._send_message(recipient_agent, message, action_override)
-                elif recipient_agent == "all":
                     self._send_message(recipient_agent, message, action_override)
                 else:
                     logger.warning(f"unknown local agent: '{recipient_agent}'")

--- a/src/mail/examples/math_dummy/__init__.py
+++ b/src/mail/examples/math_dummy/__init__.py
@@ -1,3 +1,6 @@
+from .actions import (
+    calculate_expression,
+)
 from .agent import (
     factory_math_dummy,
     math_agent_params,
@@ -5,8 +8,13 @@ from .agent import (
 from .prompts import (
     SYSPROMPT as MATH_SYSPROMPT,
 )
+from .types import (
+    action_calculate_expression,
+)
 
 __all__ = [
+    "action_calculate_expression",
+    "calculate_expression",
     "factory_math_dummy",
     "MATH_SYSPROMPT",
     "math_agent_params",

--- a/src/mail/examples/math_dummy/actions.py
+++ b/src/mail/examples/math_dummy/actions.py
@@ -1,0 +1,223 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Utility actions exposed by the math example agent."""
+
+from __future__ import annotations
+
+import ast
+import json
+import re
+from decimal import Decimal, InvalidOperation, ROUND_HALF_EVEN, localcontext
+from typing import Any, Final, Union
+
+Number = Union[int, Decimal]
+
+# Extended-precision constants to keep deterministic values for math literals.
+_CONSTANTS: Final[dict[str, Decimal]] = {
+    "pi": Decimal("3.14159265358979323846264338327950288419716939937510"),
+    "tau": Decimal("6.28318530717958647692528676655900576839433879875021"),
+    "e": Decimal("2.71828182845904523536028747135266249775724709369996"),
+}
+
+_MIN_PRECISION: Final[int] = 64
+_MAX_PRECISION: Final[int] = 4096
+
+
+class _CalculatorError(ValueError):
+    """Raised when the calculator cannot safely evaluate an expression."""
+
+
+def _estimate_precision(expr: str) -> int:
+    digit_groups = re.findall(r"\d+", expr)
+    if not digit_groups:
+        return _MIN_PRECISION
+    total_digits = sum(len(group) for group in digit_groups)
+    return max(_MIN_PRECISION, min(_MAX_PRECISION, total_digits * 2))
+
+
+def _to_decimal(value: Number) -> Decimal:
+    if isinstance(value, Decimal):
+        return value
+    return Decimal(value)
+
+
+def _format_decimal(value: Decimal, precision: int | None) -> str:
+    dec = value
+    if precision is not None:
+        quant = Decimal(1).scaleb(-precision)
+        dec = dec.quantize(quant, rounding=ROUND_HALF_EVEN)
+        formatted = format(dec, "f")
+        return formatted
+
+    formatted = format(dec, "f")
+    if "." in formatted:
+        formatted = formatted.rstrip("0").rstrip(".")
+        if not formatted:
+            formatted = "0"
+    return formatted
+
+
+def _format_result(value: Number, precision: int | None) -> tuple[str, str, bool]:
+    if isinstance(value, int):
+        dec_value = Decimal(value)
+        formatted = _format_decimal(dec_value, precision)
+        exact = str(value)
+        return exact, formatted, True
+
+    exact = _format_decimal(value, None)
+    formatted = _format_decimal(value, precision)
+    is_integer = value == value.to_integral_value()
+    return exact, formatted, is_integer
+
+
+def _apply_unary(op: ast.unaryop, operand: Number) -> Number:
+    if isinstance(op, ast.UAdd):
+        return operand
+    if isinstance(op, ast.USub):
+        return -operand
+    raise _CalculatorError("Unsupported unary operator")
+
+
+def _apply_binop(op: ast.operator, left: Number, right: Number) -> Number:
+    if isinstance(left, int) and isinstance(right, int):
+        if isinstance(op, ast.Add):
+            return left + right
+        if isinstance(op, ast.Sub):
+            return left - right
+        if isinstance(op, ast.Mult):
+            return left * right
+        if isinstance(op, ast.Pow):
+            if right < 0:
+                left_dec = _to_decimal(left)
+                return left_dec**right
+            return left**right
+        if isinstance(op, ast.FloorDiv):
+            if right == 0:
+                raise ZeroDivisionError
+            return left // right
+        if isinstance(op, ast.Mod):
+            if right == 0:
+                raise ZeroDivisionError
+            return left % right
+        if isinstance(op, ast.Div):
+            left_dec = _to_decimal(left)
+            right_dec = _to_decimal(right)
+            return left_dec / right_dec
+        raise _CalculatorError("Unsupported operator")
+
+    left_dec = _to_decimal(left)
+    right_dec = _to_decimal(right)
+
+    if isinstance(op, ast.Add):
+        return left_dec + right_dec
+    if isinstance(op, ast.Sub):
+        return left_dec - right_dec
+    if isinstance(op, ast.Mult):
+        return left_dec * right_dec
+    if isinstance(op, ast.Div):
+        return left_dec / right_dec
+    if isinstance(op, ast.FloorDiv):
+        if right_dec == 0:
+            raise ZeroDivisionError
+        result = left_dec // right_dec
+        if result == result.to_integral_value():
+            return int(result)
+        return result
+    if isinstance(op, ast.Mod):
+        if right_dec == 0:
+            raise ZeroDivisionError
+        return left_dec % right_dec
+    if isinstance(op, ast.Pow):
+        if isinstance(right, int):
+            return left_dec**right
+        raise _CalculatorError("Exponent must be an integer")
+    raise _CalculatorError("Unsupported operator")
+
+
+def _eval_node(node: ast.AST, source: str) -> Number:
+    if isinstance(node, ast.Expression):
+        return _eval_node(node.body, source)
+
+    if isinstance(node, ast.Constant):
+        value = node.value
+        if isinstance(value, bool) or value is None:
+            raise _CalculatorError("Unsupported literal")
+        if isinstance(value, int):
+            return value
+        if isinstance(value, float):
+            # Reconstruct via source to avoid binary float artifacts if available.
+            segment = ast.get_source_segment(source, node)
+            if segment is not None:
+                return Decimal(segment.replace("_", ""))
+            return Decimal(str(value))
+        raise _CalculatorError("Only numeric literals are supported")
+
+    if isinstance(node, ast.Name):
+        if node.id in _CONSTANTS:
+            return _CONSTANTS[node.id]
+        raise _CalculatorError(f"Unknown constant '{node.id}'")
+
+    if isinstance(node, ast.BinOp):
+        left = _eval_node(node.left, source)
+        right = _eval_node(node.right, source)
+        return _apply_binop(node.op, left, right)
+
+    if isinstance(node, ast.UnaryOp):
+        operand = _eval_node(node.operand, source)
+        return _apply_unary(node.op, operand)
+
+    raise _CalculatorError("Unsupported syntax in expression")
+
+
+async def calculate_expression(args: dict[str, Any]) -> str:
+    """Evaluate a basic arithmetic expression and return a structured JSON payload.
+
+    Supported grammar:
+    - numeric literals (integers or decimals)
+    - parentheses
+    - operators: +, -, *, /, //, %, **
+    - unary + and -
+    - constants: e, pi, tau
+
+    When provided, ``precision`` (0-12) controls rounding in ``formatted_result``.
+    """
+
+    expression = args.get("expression")
+    if not isinstance(expression, str) or not expression.strip():
+        return "Error: 'expression' must be a non-empty string"
+
+    precision = args.get("precision")
+    if precision is not None:
+        if not isinstance(precision, int) or not (0 <= precision <= 12):
+            return "Error: 'precision' must be an integer between 0 and 12"
+
+    try:
+        parsed = ast.parse(expression, mode="eval")
+    except SyntaxError:
+        return "Error: invalid syntax"
+
+    try:
+        with localcontext() as ctx:
+            ctx.prec = _estimate_precision(expression)
+            result: Number = _eval_node(parsed, expression)
+    except _CalculatorError as exc:
+        return f"Error: {exc}"
+    except ZeroDivisionError:
+        return "Error: division by zero"
+    except (InvalidOperation, OverflowError):
+        return "Error: unable to evaluate expression"
+
+    if isinstance(result, Decimal) and not result.is_finite():
+        return "Error: result is not a finite number"
+
+    exact_result, formatted_result, is_integer = _format_result(result, precision)
+
+    payload = {
+        "expression": expression,
+        "result": exact_result,
+        "formatted_result": formatted_result,
+        "precision": precision,
+        "is_integer": is_integer,
+    }
+
+    return json.dumps(payload)

--- a/src/mail/examples/math_dummy/prompts.py
+++ b/src/mail/examples/math_dummy/prompts.py
@@ -1,1 +1,45 @@
-SYSPROMPT = """You are a math agent. Show steps. Use tools if provided; otherwise reason carefully."""
+SYSPROMPT = """You are math, the swarm's quantitative specialist operating inside the
+Multi-Agent Interface Layer (MAIL).
+
+Capabilities
+- Solve symbolic and numeric problems exactly when possible, showing the key
+  algebraic or numerical steps before the final result.
+- You may invoke the `calculate_expression` action for deterministic arithmetic
+  on expressions involving +, -, *, /, //, %, **, parentheses, and constants
+  (`pi`, `e`, `tau`). It returns JSON with exact `result` (string), a rounded
+  `formatted_result`, and `is_integer`. Use it to sanity-check or accelerate
+  precise computes; round via the optional `precision` argument (0-12 places).
+- You may call the MAIL tools provided to you:
+  * `send_response(target, subject, body)`: reply to the agent that contacted you
+    (usually `supervisor`). Target must be the original sender address. Default
+    the subject to `Re: <incoming subject>` unless told otherwise.
+  * `send_request(target, subject, body)`: ask `supervisor` or another listed
+    comm target for data you truly need. Be precise about the deliverable and
+    desired format; keep requests rare and focused.
+  * `acknowledge_broadcast(reason?)`: confirm a broadcast you will follow.
+  * `ignore_broadcast(reason?)`: drop a broadcast you do not need to handle.
+
+Constraints
+- You cannot talk to the user directly or call `task_complete`; respond only
+  through MAIL tools. Stay within math/domain reasoning—no network access or
+  unstated external tools.
+- Keep subjects short and bodies plain text (no XML/JSON unless requested).
+  Include units, assumptions, and any uncertainty in the body of your reply.
+
+Workflow
+1. Read the incoming MAIL envelope (sender, subject, body, constraints).
+2. Decide whether you can solve immediately. If information is missing, either
+   issue one targeted `send_request` or explain the limitation in your response.
+3. Perform the working step by step. Use `calculate_expression` when it improves
+   accuracy or efficiency; parse the JSON payload and cite the numeric result.
+   Provide intermediate reasoning, then present the final answer clearly at the
+   end (e.g., `Final:` line).
+4. Answer in a single turn with `send_response` to the originator. Do not start
+   side conversations unless absolutely required.
+
+Safety
+- If instructions conflict or inputs are impossible, state the issue instead of
+  guessing.
+- Stay inside quantitative reasoning; escalate via `send_request` if asked to do
+  tasks outside your scope.
+"""

--- a/src/mail/examples/math_dummy/types.py
+++ b/src/mail/examples/math_dummy/types.py
@@ -1,0 +1,24 @@
+from mail.api import MAILAction
+
+action_calculate_expression = MAILAction(
+    name="calculate_expression",
+    description="Evaluate a basic arithmetic expression with +, -, *, /, %, //, **, and parentheses.",
+    parameters={
+        "type": "object",
+        "properties": {
+            "expression": {
+                "type": "string",
+                "description": "The arithmetic expression to evaluate.",
+            },
+            "precision": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 12,
+                "description": "Optional number of decimal places for the formatted result.",
+            },
+        },
+        "required": ["expression"],
+    },
+    function="mail.examples.math_dummy.actions:calculate_expression",
+)
+

--- a/src/mail/factories/base.py
+++ b/src/mail/factories/base.py
@@ -197,7 +197,7 @@ def base_agent_factory(
         for output in res.output:
             if isinstance(output, dict):
                 if output["type"] == "function_call":
-                    tool_calls.append(output)
+                    tool_calls.append(output) # type: ignore
                 elif output["type"] == "message":
                     message = output["content"][0]["text"]
             elif output.type == "function_call":

--- a/src/mail/factories/base.py
+++ b/src/mail/factories/base.py
@@ -195,7 +195,12 @@ def base_agent_factory(
         message: str = ""
 
         for output in res.output:
-            if output.type == "function_call":
+            if isinstance(output, dict):
+                if output["type"] == "function_call":
+                    tool_calls.append(output)
+                elif output["type"] == "message":
+                    message = output["content"][0]["text"]
+            elif output.type == "function_call":
                 tool_calls.append(output)
             elif output.type == "message":
                 message = output.content[0].text

--- a/src/mail/net/registry.py
+++ b/src/mail/net/registry.py
@@ -61,7 +61,7 @@ class SwarmRegistry:
             volatile=False,  # Local swarm is never volatile
         )
         logger.info(
-            f"registered local swarm: '{self.local_swarm_name}' at '{base_url}'"
+            f"registered local swarm: '{self.local_swarm_name}' at {base_url}"
         )
 
     def register_swarm(
@@ -98,7 +98,7 @@ class SwarmRegistry:
             volatile=volatile,
         )
         logger.info(
-            f"registered remote swarm: '{swarm_name}' at '{base_url}' (volatile: '{volatile}')"
+            f"registered remote swarm: '{swarm_name}' at {base_url} (volatile: '{volatile}')"
         )
 
         # Save persistent endpoints if this swarm is non-volatile

--- a/src/mail/net/types.py
+++ b/src/mail/net/types.py
@@ -66,6 +66,18 @@ class GetRootResponse(TypedDict):
     """The version of MAIL that is running."""
 
 
+
+class GetWhoamiResponse(TypedDict):
+    """
+    Response for the MAIL server endpoint `GET /whoami`.
+    """
+    username: str
+    """The username of the caller."""
+
+    role: str
+    """The role of the caller."""
+
+
 class GetStatusResponse(TypedDict):
     """
     Response for the MAIL server endpoint `GET /status`.

--- a/src/mail/server.py
+++ b/src/mail/server.py
@@ -23,12 +23,15 @@ import mail.utils as utils
 from mail.config.server import ServerConfig
 from mail.core.message import (
     MAIL_MESSAGE_TYPES,
+    MAILAddress,
+    MAILBroadcast,
     MAILInterswarmMessage,
     MAILMessage,
     MAILRequest,
     MAILResponse,
-    create_agent_address,
     create_user_address,
+    format_agent_address,
+    parse_agent_address,
 )
 from mail.net import types as types
 from mail.net.registry import SwarmRegistry
@@ -133,16 +136,14 @@ async def _server_startup() -> None:
         raise e
 
     # ensure necessary auth endpoints are registered
-    auth_endpoints = ["AUTH_ENDPOINT", "TOKEN_INFO_ENDPOINT"]
-    for endpoint in auth_endpoints:
-        if endpoint not in os.environ:
-            logger.error(f"required environment variable '{endpoint}' is not set")
-            raise Exception(f"required environment variable '{endpoint}' is not set")
+    await utils.auth.check_auth_endpoints()
+    logger.info(f"endpoint 'AUTH_ENDPOINT' = {os.getenv('AUTH_ENDPOINT')}")
+    logger.info(f"endpoint 'TOKEN_INFO_ENDPOINT' = {os.getenv('TOKEN_INFO_ENDPOINT')}")
 
     # ensure necessary swarm endpoints are registered
     swarm_endpoints = ["SWARM_REGISTRY_FILE", "SWARM_SOURCE"]
     for endpoint in swarm_endpoints:
-        if endpoint not in os.environ:
+        if endpoint not in os.environ or os.getenv(endpoint) is None:
             logger.error(f"required environment variable '{endpoint}' is not set")
             raise Exception(f"required environment variable '{endpoint}' is not set")
 
@@ -400,6 +401,8 @@ async def message(request: Request):
             f"received message from user or admin '{caller_id}': '{body[:50]}...'"
         )
     except Exception as e:
+        if isinstance(e, HTTPException):
+            raise e
         logger.error(f"error parsing request: '{e}'")
         raise HTTPException(
             status_code=400, detail=f"error parsing request: {e.with_traceback(None)}"
@@ -536,6 +539,8 @@ async def register_swarm(request: Request):
         )
 
     except Exception as e:
+        if isinstance(e, HTTPException):
+            raise e
         logger.error(f"error registering swarm: '{e}'")
         raise HTTPException(
             status_code=500, detail=f"error registering swarm: '{str(e)}'"
@@ -600,6 +605,8 @@ async def receive_interswarm_message(request: Request):
             f"received message from {source_agent} to {target_agent}: {message.get('subject', 'unknown')}..."
         )
     except Exception as e:
+        if isinstance(e, HTTPException):
+            raise e
         logger.error(f"error parsing request: '{e}'")
         raise HTTPException(
             status_code=400, detail=f"error parsing request: {e.with_traceback(None)}"
@@ -611,6 +618,8 @@ async def receive_interswarm_message(request: Request):
 
     # MAIL process
     try:
+        metadata = data.get("metadata") or {}
+
         logger.info(f"creating MAIL message for swarm '{source_swarm}'...")
         new_message = MAILMessage(
             id=str(uuid.uuid4()),
@@ -621,6 +630,14 @@ async def receive_interswarm_message(request: Request):
         logger.info(
             f"submitting message '{new_message['id']}' to agent MAIL and waiting for response..."
         )
+        if metadata.get("stream"):
+            ignore_pings = bool(metadata.get("ignore_stream_pings"))
+            ping_interval = None if ignore_pings else 15000
+            return await swarm_mail.submit_message_stream(
+                new_message,
+                ping_interval=ping_interval,
+            )
+
         submit_result = await swarm_mail.submit_message(new_message)
         # Support both (response, events) and response-only returns
         if isinstance(submit_result, tuple) and len(submit_result) == 2:
@@ -724,6 +741,20 @@ async def send_interswarm_message(request: Request):
     """
     Send an interswarm message to another swarm.
     Intended for users and admins.
+
+    Args:
+        targets: The targets to send the message to.
+        body: The message to send.
+        subject: The subject of the message.
+        msg_type: The type of the message.
+        task_id: The task ID of the message.
+        routing_info: The routing information for the message.
+        stream: Whether to stream the message.
+        ignore_stream_pings: Whether to ignore stream pings.
+        user_token: The user token to use for the message.
+
+    Returns:
+        The response from the message.
     """
     logger.info("endpoint accessed: 'POST /interswarm/send'")
 
@@ -735,37 +766,102 @@ async def send_interswarm_message(request: Request):
 
         # parse request
         data = await request.json()
-        target_agent = data.get("target_agent")
-        message_content = data.get("message")
+        targets = data.get("targets")
+        message_content = data.get("body")
+        subject = data.get("subject", "Interswarm Message")
+        msg_type = data.get("msg_type", "request")
+        task_id = data.get("task_id") or str(uuid.uuid4())
+        routing_info = data.get("routing_info") or {}
+        stream_requested = bool(data.get("stream"))
+        ignore_pings = bool(data.get("ignore_stream_pings"))
+        if stream_requested:
+            routing_info["stream"] = True
+            if ignore_pings:
+                routing_info["ignore_stream_pings"] = True
+        elif ignore_pings:
+            routing_info["ignore_stream_pings"] = True
+
         user_token = data.get("user_token")
 
-        if not target_agent or not message_content:
+        if message_content is not None and not isinstance(message_content, str):
+            message_content = str(message_content)
+
+        if subject is not None and not isinstance(subject, str):
+            subject = str(subject)
+
+        if not targets or not message_content:
             raise HTTPException(
-                status_code=400, detail="target_agent and message are required"
+                status_code=400,
+                detail="'targets' and 'body' are required",
             )
 
         if not user_token or user_token not in user_mail_instances:
-            raise HTTPException(status_code=400, detail="Valid user_token is required")
+            raise HTTPException(status_code=400, detail="valid user_token is required")
 
         mail_instance = user_mail_instances[user_token]
 
-        # Create MAIL message
-        mail_message = MAILMessage(
-            id=str(uuid.uuid4()),
-            timestamp=datetime.datetime.now(datetime.UTC).isoformat(),
-            message=MAILRequest(
-                task_id=str(uuid.uuid4()),
-                request_id=str(uuid.uuid4()),
-                sender=create_user_address(f"{user_id}@{local_swarm_name}"),
-                recipient=create_agent_address(f"{target_agent}"),
-                subject="Interswarm Message",
-                body=message_content,
-                sender_swarm=local_swarm_name,
-                recipient_swarm=target_agent.split("@")[1],
-                routing_info={},
-            ),
-            msg_type="request",
-        )
+        sender_address = create_user_address(f"{user_id}@{local_swarm_name}")
+
+        def _build_request(target: str) -> MAILMessage:
+            recipient_agent, recipient_swarm = parse_agent_address(target)
+            recipient_address = format_agent_address(recipient_agent, recipient_swarm)
+            return MAILMessage(
+                id=str(uuid.uuid4()),
+                timestamp=datetime.datetime.now(datetime.UTC).isoformat(),
+                message=MAILRequest(
+                    task_id=task_id,
+                    request_id=str(uuid.uuid4()),
+                    sender=sender_address,
+                    recipient=recipient_address,
+                    subject=subject,
+                    body=message_content,
+                    sender_swarm=local_swarm_name,
+                    recipient_swarm=recipient_swarm or local_swarm_name,
+                    routing_info=routing_info,
+                ),
+                msg_type="request",
+            )
+
+        def _build_broadcast() -> MAILMessage:
+            recipients: list[MAILAddress] = []
+            recipient_swarms: set[str] = set()
+            for target in targets:
+                agent, swarm = parse_agent_address(target)
+                recipients.append(format_agent_address(agent, swarm))
+                if swarm:
+                    recipient_swarms.add(swarm)
+            return MAILMessage(
+                id=str(uuid.uuid4()),
+                timestamp=datetime.datetime.now(datetime.UTC).isoformat(),
+                message=MAILBroadcast(
+                    task_id=task_id,
+                    broadcast_id=str(uuid.uuid4()),
+                    sender=sender_address,
+                    recipients=recipients,
+                    subject=subject,
+                    body=message_content,
+                    sender_swarm=local_swarm_name,
+                    recipient_swarms=list(recipient_swarms) or [local_swarm_name],
+                    routing_info=routing_info,
+                ),
+                msg_type="broadcast",
+            )
+
+        match msg_type:
+            case "request":
+                if len(targets) != 1:
+                    raise HTTPException(
+                        status_code=400,
+                        detail="'request' messages require exactly one target",
+                    )
+                mail_message = _build_request(targets[0])
+            case "broadcast":
+                mail_message = _build_broadcast()
+            case _:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"msg_type '{msg_type}' is not supported for interswarm send",
+                )
 
         # Route the message
         if mail_instance.enable_interswarm:
@@ -776,10 +872,12 @@ async def send_interswarm_message(request: Request):
             )
         else:
             raise HTTPException(
-                status_code=503, detail="Interswarm router not available"
+                status_code=503, detail="interswarm router not available"
             )
 
     except Exception as e:
+        if isinstance(e, HTTPException):
+            raise e
         logger.error(f"error sending interswarm message: '{e}'")
         raise HTTPException(
             status_code=500, detail=f"error sending interswarm message: '{str(e)}'"

--- a/src/mail/server.py
+++ b/src/mail/server.py
@@ -305,6 +305,23 @@ async def root():
     )
 
 
+@app.get("/whoami", dependencies=[Depends(utils.caller_is_admin_or_user)])
+async def whoami(request: Request):
+    """
+    Get the username and role of the caller.
+    """
+    logger.info("endpoint accessed: 'GET /whoami'")
+    try:
+        caller_info = await utils.extract_token_info(request)
+        caller_id = utils.generate_user_id(caller_info)
+        return types.GetWhoamiResponse(username=caller_id, role=caller_info["role"])
+    except Exception as e:
+        if isinstance(e, HTTPException):
+            raise e
+        logger.error(f"error getting whoami: '{e}'")
+        raise HTTPException(status_code=500, detail=f"error getting whoami: {e.with_traceback(None)}")
+
+
 @app.get("/status", dependencies=[Depends(utils.caller_is_admin_or_user)])
 async def status(request: Request):
     """

--- a/swarms.json
+++ b/swarms.json
@@ -30,6 +30,7 @@
                 "name": "math",
                 "factory": "python::mail.examples.math_dummy.agent:factory_math_dummy",
                 "comm_targets": ["supervisor", "weather"],
+                "actions": ["calculate_expression"],
                 "agent_params": { 
                     "llm": "openai/gpt-5-mini",
                     "system": "python::mail.examples.math_dummy.prompts:SYSPROMPT"
@@ -49,6 +50,19 @@
                     }
                 },
                 "function": "python::mail.examples.weather_dummy.actions:get_weather_forecast"
+            },
+            {
+                "name": "calculate_expression",
+                "description": "Evaluate a basic arithmetic expression inside the math agent.",
+                "parameters": { 
+                    "type": "object",
+                    "properties": {
+                        "expression": { "type": "string", "description": "Expression to evaluate" },
+                        "precision": { "type": "integer", "minimum": 0, "maximum": 12, "description": "Optional number of decimal places for the formatted result" }
+                    },
+                    "required": ["expression"]
+                },
+                "function": "python::mail.examples.math_dummy.actions:calculate_expression"
             }
         ]
     },
@@ -86,6 +100,7 @@
                 "name": "math",
                 "factory": "python::mail.examples.math_dummy.agent:factory_math_dummy",
                 "comm_targets": ["supervisor", "weather"],
+                "actions": ["calculate_expression"],
                 "agent_params": { 
                     "llm": "openai/gpt-5-mini",
                     "system": "python::mail.examples.math_dummy.prompts:SYSPROMPT",
@@ -106,6 +121,19 @@
                     }
                 },
                 "function": "python::mail.examples.weather_dummy.actions:get_weather_forecast"
+            },
+            {
+                "name": "calculate_expression",
+                "description": "Evaluate a basic arithmetic expression inside the math agent.",
+                "parameters": { 
+                    "type": "object",
+                    "properties": {
+                        "expression": { "type": "string", "description": "Expression to evaluate" },
+                        "precision": { "type": "integer", "minimum": 0, "maximum": 12, "description": "Optional number of decimal places for the formatted result" }
+                    },
+                    "required": ["expression"]
+                },
+                "function": "python::mail.examples.math_dummy.actions:calculate_expression"
             }
         ]
     },
@@ -143,6 +171,7 @@
                 "name": "math",
                 "factory": "python::mail.examples.math_dummy.agent:factory_math_dummy",
                 "comm_targets": ["supervisor", "weather"],
+                "actions": ["calculate_expression"],
                 "agent_params": { 
                     "llm": "openai/gpt-5-mini",
                     "system": "python::mail.examples.math_dummy.prompts:SYSPROMPT",
@@ -163,6 +192,19 @@
                     }
                 },
                 "function": "python::mail.examples.weather_dummy.actions:get_weather_forecast"
+            },
+            {
+                "name": "calculate_expression",
+                "description": "Evaluate a basic arithmetic expression inside the math agent.",
+                "parameters": { 
+                    "type": "object",
+                    "properties": {
+                        "expression": { "type": "string", "description": "Expression to evaluate" },
+                        "precision": { "type": "integer", "minimum": 0, "maximum": 12, "description": "Optional number of decimal places for the formatted result" }
+                    },
+                    "required": ["expression"]
+                },
+                "function": "python::mail.examples.math_dummy.actions:calculate_expression"
             }
         ]
     },

--- a/tests/network/test_interswarm_endpoints.py
+++ b/tests/network/test_interswarm_endpoints.py
@@ -6,6 +6,7 @@ import uuid
 
 import pytest
 from fastapi.testclient import TestClient
+from sse_starlette import EventSourceResponse, ServerSentEvent
 
 from mail.core.message import (
     MAILInterswarmMessage,
@@ -70,6 +71,337 @@ def test_interswarm_message_success(monkeypatch: pytest.MonkeyPatch):
         assert data["msg_type"] == "response"
         # Response recipient should be original sender
         assert data["message"]["recipient"]["address"] == payload["sender"]["address"]
+
+
+@pytest.mark.usefixtures("patched_server")
+def test_interswarm_message_streaming_response(monkeypatch: pytest.MonkeyPatch):
+    """
+    Verify that streaming metadata returns an SSE response with task events.
+    """
+    from mail.server import app
+
+    monkeypatch.setattr(
+        "mail.utils.auth.get_token_info",
+        lambda token: _async_return({"role": "agent", "id": "ag-stream"}),
+    )
+
+    captured_ping: list[int | None] = []
+
+    async def fake_stream(
+        self,
+        message,
+        timeout: float = 3600.0,
+        resume_from=None,
+        *,
+        ping_interval: int | None = 15000,
+        **kwargs,
+    ):
+        task_id = message["message"]["task_id"]
+        captured_ping.append(ping_interval)
+
+        async def event_gen():
+            yield ServerSentEvent(
+                event="new_message",
+                data={
+                    "task_id": task_id,
+                    "extra_data": {"full_message": message},
+                },
+            )
+            yield ServerSentEvent(
+                event="task_complete",
+                data={"task_id": task_id, "response": "done"},
+            )
+
+        return EventSourceResponse(event_gen(), ping=ping_interval)
+
+    monkeypatch.setattr("mail.MAILSwarm.submit_message_stream", fake_stream, raising=True)
+
+    with TestClient(app) as client:
+        payload: MAILRequest = MAILRequest(
+            task_id=str(uuid.uuid4()),
+            request_id=str(uuid.uuid4()),
+            sender=format_agent_address("remote-agent", "remote"),
+            recipient=create_agent_address("supervisor"),
+            subject="Ping",
+            body="Hello from remote",
+            sender_swarm="remote",
+            recipient_swarm="example",
+            routing_info={"stream": True},
+        )
+        wrapper: MAILInterswarmMessage = MAILInterswarmMessage(
+            message_id=str(uuid.uuid4()),
+            source_swarm="remote",
+            target_swarm="example",
+            timestamp=datetime.datetime.now(datetime.UTC).isoformat(),
+            payload=payload,
+            msg_type="request",
+            auth_token="token-123",
+            metadata={"expect_response": True, "stream": True},
+        )
+
+        with client.stream(
+            "POST",
+            "/interswarm/message",
+            headers={"Authorization": "Bearer test-key"},
+            json=wrapper,
+        ) as response:
+            assert response.status_code == 200
+            assert response.headers["content-type"].startswith("text/event-stream")
+            raw_events: list[str] = []
+            for line in response.iter_lines():
+                if not line:
+                    continue
+                if isinstance(line, bytes):
+                    line = line.decode("utf-8")
+                raw_events.append(line.strip())
+
+        assert any(
+            line.startswith("event:new_message") or line.startswith("event: new_message")
+            for line in raw_events
+        )
+        assert any(
+            line.startswith("event:task_complete") or line.startswith("event: task_complete")
+            for line in raw_events
+        )
+
+        data_lines = [line for line in raw_events if line.startswith("data:")]
+        assert any(payload["task_id"] in line for line in data_lines)
+        assert captured_ping == [15000]
+
+
+@pytest.mark.usefixtures("patched_server")
+def test_interswarm_message_streaming_ignores_pings(monkeypatch: pytest.MonkeyPatch):
+    """
+    Ensure that `ignore_stream_pings` disables heartbeat emission.
+    """
+    from mail.server import app
+
+    monkeypatch.setattr(
+        "mail.utils.auth.get_token_info",
+        lambda token: _async_return({"role": "agent", "id": "ag-no-ping"}),
+    )
+
+    captured_ping: list[int | None] = []
+
+    async def fake_stream(
+        self,
+        message,
+        timeout: float = 3600.0,
+        resume_from=None,
+        *,
+        ping_interval: int | None = 15000,
+        **kwargs,
+    ):
+        captured_ping.append(ping_interval)
+
+        async def event_gen():
+            yield ServerSentEvent(
+                event="task_complete",
+                data={"task_id": message["message"]["task_id"], "response": "ok"},
+            )
+
+        return EventSourceResponse(event_gen(), ping=ping_interval)
+
+    monkeypatch.setattr("mail.MAILSwarm.submit_message_stream", fake_stream, raising=True)
+
+    with TestClient(app) as client:
+        payload: MAILRequest = MAILRequest(
+            task_id=str(uuid.uuid4()),
+            request_id=str(uuid.uuid4()),
+            sender=format_agent_address("remote-agent", "remote"),
+            recipient=create_agent_address("supervisor"),
+            subject="Ping",
+            body="Hello from remote",
+            sender_swarm="remote",
+            recipient_swarm="example",
+            routing_info={"stream": True, "ignore_stream_pings": True},
+        )
+        wrapper: MAILInterswarmMessage = MAILInterswarmMessage(
+            message_id=str(uuid.uuid4()),
+            source_swarm="remote",
+            target_swarm="example",
+            timestamp=datetime.datetime.now(datetime.UTC).isoformat(),
+            payload=payload,
+            msg_type="request",
+            auth_token="token-123",
+            metadata={
+                "expect_response": True,
+                "stream": True,
+                "ignore_stream_pings": True,
+            },
+        )
+
+        with client.stream(
+            "POST",
+            "/interswarm/message",
+            headers={"Authorization": "Bearer test-key"},
+            json=wrapper,
+        ) as response:
+            assert response.status_code == 200
+            assert response.headers["content-type"].startswith("text/event-stream")
+            events: list[str] = []
+            for line in response.iter_lines():
+                if not line:
+                    continue
+                if isinstance(line, bytes):
+                    line = line.decode("utf-8")
+                events.append(line.strip())
+
+        assert captured_ping == [None]
+        assert any(
+            line.startswith("event:task_complete") or line.startswith("event: task_complete")
+            for line in events
+        )
+
+
+@pytest.mark.usefixtures("patched_server")
+def test_interswarm_send_custom_request(monkeypatch: pytest.MonkeyPatch):
+    """
+    Users can customize subject, msg_type, and routing flags when sending interswarm messages.
+    """
+    from mail.server import app, user_mail_instances
+
+    monkeypatch.setattr(
+        "mail.utils.auth.get_token_info",
+        lambda token: _async_return({"role": "user", "id": "user-123"}),
+    )
+
+    captured: dict[str, MAILMessage] = {}
+
+    class DummyMail:
+        enable_interswarm = True
+
+        async def route_interswarm_message(self, message: MAILMessage) -> MAILMessage:
+            captured["message"] = message
+            return message
+        
+        async def shutdown(self) -> None:
+            pass
+
+    user_mail_instances["test-token"] = DummyMail() # type: ignore[assignment]
+
+    with TestClient(app) as client:
+        payload = {
+            "targets": ["helper@remote"],
+            "body": "Hello remote",
+            "subject": "Custom Subject",
+            "msg_type": "request",
+            "task_id": "task-xyz",
+            "stream": True,
+            "ignore_stream_pings": True,
+            "routing_info": {"foo": "bar"},
+            "user_token": "test-token",
+        }
+
+        r = client.post(
+            "/interswarm/send",
+            headers={"Authorization": "Bearer test-key"},
+            json=payload,
+        )
+
+        assert r.status_code == 200
+        assert "message" in captured
+        message = captured["message"]
+        assert message["msg_type"] == "request"
+        assert message["message"]["subject"] == "Custom Subject"
+        assert message["message"]["body"] == "Hello remote"
+        assert message["message"]["task_id"] == "task-xyz"
+        assert message["message"]["routing_info"]["foo"] == "bar" # type: ignore
+        assert message["message"]["routing_info"]["stream"] is True # type: ignore
+        assert message["message"]["routing_info"]["ignore_stream_pings"] is True # type: ignore
+        assert message["message"]["recipient"]["address"] == "helper@remote" # type: ignore
+        assert message["message"]["recipient_swarm"] == "remote" # type: ignore
+
+
+@pytest.mark.usefixtures("patched_server")
+def test_interswarm_send_broadcast(monkeypatch: pytest.MonkeyPatch):
+    """
+    Users can send broadcast interswarm messages to multiple targets.
+    """
+    from mail.server import app, user_mail_instances
+
+    monkeypatch.setattr(
+        "mail.utils.auth.get_token_info",
+        lambda token: _async_return({"role": "user", "id": "user-456"}),
+    )
+
+    captured: dict[str, MAILMessage] = {}
+
+    class DummyMAILInstance:
+        enable_interswarm = True
+
+        async def route_interswarm_message(self, message: MAILMessage) -> MAILMessage:
+            captured["message"] = message
+            return message
+
+        async def shutdown(self) -> None:
+            pass
+
+    user_mail_instances["token-broadcast"] = DummyMAILInstance() # type: ignore[assignment]
+
+    with TestClient(app) as client:
+        payload = {
+            "targets": ["helper@remote", "analyst"],
+            "body": "Broadcast body",
+            "subject": "Broadcast",
+            "msg_type": "broadcast",
+            "user_token": "token-broadcast",
+        }
+
+        r = client.post(
+            "/interswarm/send",
+            headers={"Authorization": "Bearer test-key"},
+            json=payload,
+        )
+
+        assert r.status_code == 200
+        message = captured["message"]
+        assert message["msg_type"] == "broadcast"
+        recipients = message["message"]["recipients"]  # type: ignore
+        addresses = {recipient["address"] for recipient in recipients}
+        assert addresses == {"helper@remote", "analyst"}
+        assert "remote" in message["message"]["recipient_swarms"]  # type: ignore
+
+
+@pytest.mark.usefixtures("patched_server")
+def test_interswarm_send_invalid_msg_type(monkeypatch: pytest.MonkeyPatch):
+    """
+    Unsupported message types should return a 400 error.
+    """
+    from mail.server import app, user_mail_instances
+
+    monkeypatch.setattr(
+        "mail.utils.auth.get_token_info",
+        lambda token: _async_return({"role": "user", "id": "user-789"}),
+    )
+
+    class DummyMAILInstance:
+        enable_interswarm = True
+
+        async def route_interswarm_message(self, message: MAILMessage) -> MAILMessage:  # noqa: ARG002
+            return message
+
+        async def shutdown(self) -> None:
+            pass
+
+    user_mail_instances["token-invalid"] = DummyMAILInstance() # type: ignore[assignment]
+
+    with TestClient(app) as client:
+        payload = {
+            "targets": ["helper@remote"],
+            "body": "Body",
+            "msg_type": "interrupt",
+            "user_token": "token-invalid",
+        }
+
+        r = client.post(
+            "/interswarm/send",
+            headers={"Authorization": "Bearer test-key"},
+            json=payload,
+        )
+
+        assert r.status_code == 400
+        assert "not supported" in r.json()["detail"]
 
 
 @pytest.mark.usefixtures("patched_server")

--- a/tests/unit/test_mail_client.py
+++ b/tests/unit/test_mail_client.py
@@ -167,7 +167,7 @@ async def test_mail_client_rest_endpoints() -> None:
             await client.post_interswarm_message(EXAMPLE_INTERSWARM_MESSAGE)  # type: ignore[arg-type]
             await client.post_interswarm_response(EXAMPLE_MAIL_MESSAGE)  # type: ignore[arg-type]
             await client.send_interswarm_message(
-                "agent@remote", "hello", user_token="demo-user"
+                "hello", targets=["agent@remote"], user_token="demo-user"
             )
             load = await client.load_swarm_from_json("{}")
 
@@ -200,8 +200,8 @@ async def test_mail_client_rest_endpoints() -> None:
     assert captured["registrations"][0]["metadata"] == {"label": "alpha"}
     assert captured["interswarm_message"][0]["msg_type"] == "response"
     assert captured["interswarm_response"][0]["msg_type"] == "response"
-    assert captured["interswarm_send"][0]["target_agent"] == "agent@remote"
-    assert captured["interswarm_send"][0]["message"] == "hello"
+    assert captured["interswarm_send"][0]["targets"] == ["agent@remote"]
+    assert captured["interswarm_send"][0]["body"] == "hello"
     assert captured["interswarm_send"][0]["user_token"] == "demo-user"
     assert captured["swarm_load"][0]["json"] == "{}"
 


### PR DESCRIPTION
- Streaming can now be optionally enabled during interswarm communication by adding the following to `metadata`: `stream = True`
- Endpoint `POST /interswarm/send` now accepts a much larger number of params, similar to `POST /message`
- New endpoint `GET /whoami` can be accessed by users and admins to obtain swarm usernames and roles given a valid auth token
- Prettier CLI (using `rich`) with XML-formatted message events
- Agent `math` now has a `calculate_expression` action and a better sysprompt
- Various bug fixes
- Updated docs; all tests passing