### PR TITLE
Added MAIL core tool `await_message` to explicitly end an agent's turn; more robust tool responses

### DIFF
--- a/docs/agents-and-tools.md
+++ b/docs/agents-and-tools.md
@@ -23,6 +23,7 @@
 - `send_broadcast(subject, body)` → fans a `MAILBroadcast` out to every agent in the local swarm.
 - `acknowledge_broadcast(note=None)` → records the broadcast in agent memory without replying; the optional note stays internal.
 - `ignore_broadcast(reason=None)` → explicitly drops the broadcast and skips both memory storage and outbound mail; optional reason is internal only.
+- `await_message(reason=None)` → signals that the agent has no further output this turn and should be rescheduled when new mail arrives; an optional reason is surfaced in SSE events and tool-call history for debugging.
 - `send_interswarm_broadcast(subject, body, target_swarms=[])` → (supervisor + interswarm) sends a broadcast to selected remote swarms, defaulting to all when the list is empty.
 - `discover_swarms(discovery_urls)` → (supervisor + interswarm) hands discovery endpoints to the registry so it can import additional swarms.
 - `task_complete(finish_message)` → (supervisor) broadcasts the final answer and tells the runtime the task loop is finished.

--- a/docs/api.md
+++ b/docs/api.md
@@ -377,6 +377,15 @@ def create_ignore_broadcast_tool(
   - **Parameters**: `style: Literal["completions", "responses"]` – determines returned schema format.
   - **Returns**: `dict[str, Any]` – Tool metadata for `ignore_broadcast`.
   - **Summary**: Allows agents to discard a broadcast intentionally, optionally recording an internal reason while ensuring no acknowledgement is emitted.
+##### `create_await_message_tool`
+```python
+def create_await_message_tool(
+    style="completions"
+) -> dict[str, Any]
+```
+  - **Parameters**: `style: Literal["completions", "responses"]` – specifies the OpenAI schema flavor to emit.
+  - **Returns**: `dict[str, Any]` – Tool description for `await_message` with an optional `reason` field.
+  - **Summary**: Gives agents a MAIL-native way to yield their turn once they have no additional output; the optional reason is surfaced in runtime events and tool-call history for observability.
 ##### `create_task_complete_tool`
 ```python
 def create_task_complete_tool(
@@ -395,8 +404,8 @@ def create_mail_tools(
 ) -> list[dict[str, Any]]
 ```
   - **Parameters**: `targets: list[str]` – baseline intra-swarm recipients; `enable_interswarm: bool` – toggles remote routing support; `style: Literal["completions", "responses"]` – OpenAI schema variant shared by all generated tools.
-  - **Returns**: `list[dict[str, Any]]` – Bundled request, response, acknowledgement, and ignore tools configured with the provided options.
-  - **Summary**: Supplies a ready-to-install toolkit for standard agents so they can message peers, acknowledge broadcasts, or silence them without bespoke configuration.
+  - **Returns**: `list[dict[str, Any]]` – Bundled request, response, acknowledgement, ignore, and await tools configured with the provided options.
+  - **Summary**: Supplies a ready-to-install toolkit for standard agents so they can message peers, manage broadcasts, or explicitly wait for new mail without bespoke configuration.
 ##### `create_supervisor_tools`
 ```python
 def create_supervisor_tools(

--- a/spec/SPEC.md
+++ b/spec/SPEC.md
@@ -194,6 +194,12 @@ All types are defined in [spec/MAIL-core.schema.json](/spec/MAIL-core.schema.jso
 - **Optional Parameters**: `reason` (string)
 - **Returns**: None mandated by this spec.
 
+### `await_message`
+
+- Indicate that the agent is finished with its current turn and should be scheduled again once a new MAIL message arrives.
+- **Optional Parameters**: `reason` (string)
+- **Returns**: None mandated by this spec.
+
 ## REST Transport
 
 **Authoritative contract**: [spec/openapi.yaml](/spec/openapi.yaml) (OpenAPI 3.1[^openapi]).

--- a/src/mail/core/tools.py
+++ b/src/mail/core/tools.py
@@ -29,6 +29,7 @@ MAIL_TOOL_NAMES = [
     "task_complete",
     "acknowledge_broadcast",
     "ignore_broadcast",
+    "await_message",
 ]
 
 
@@ -446,6 +447,23 @@ Furthermore, this broadcast will be sent to all agents in the swarm to notify th
     return pydantic_model_to_tool(task_complete, name="task_complete", style=style)
 
 
+def create_await_message_tool(
+    style: Literal["completions", "responses"] = "completions",
+) -> dict[str, Any]:
+    """
+    Create a MAIL await message tool to wait for a message.
+    """
+    class await_message(BaseModel):
+        """Wait until another message is received."""
+
+        reason: Optional[str] = Field(  # noqa: UP045
+            default=None,
+            description="Optional reason for waiting.",
+        )
+
+
+    return pydantic_model_to_tool(await_message, name="await_message", style=style)
+
 def create_mail_tools(
     targets: list[str],
     enable_interswarm: bool = False,
@@ -464,6 +482,7 @@ def create_mail_tools(
         create_response_tool(targets, enable_interswarm, style),
         create_acknowledge_broadcast_tool(style),
         create_ignore_broadcast_tool(style),
+        create_await_message_tool(style),
     ]
 
 

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -43,17 +43,17 @@ def test_execute_action_tool_normal_and_override():
 
     async def run():
         # Normal path: resolves through actions mapping and wraps as tool response
-        res1 = await _action_echo_core.execute(
+        res1_status, res1_message = await _action_echo_core.execute(
             _call("echo", {"x": 3}),
             {"echo": _action_echo_core},
         )
-        assert res1["role"] == "tool" and "echo:3" in res1["content"]
+        assert res1_status == "success" and "echo:3" in res1_message["content"]
 
         # Override returns a string or dict directly
-        res2 = await _action_echo_core.execute(
+        res2_status, res2_message = await _action_echo_core.execute(
             _call("echo", {"x": "hi"}),
             action_override=_override_upper,
         )
-        assert res2["content"].startswith("OVERRIDE:")
+        assert res2_status == "success" and res2_message["content"].startswith("OVERRIDE:")
 
     asyncio.run(run())

--- a/tests/unit/test_tools_specs.py
+++ b/tests/unit/test_tools_specs.py
@@ -7,6 +7,7 @@ import pytest
 
 from mail.core.tools import (
     convert_call_to_mail_message,
+    create_await_message_tool,
     create_mail_tools,
     create_request_tool,
     create_supervisor_tools,
@@ -78,6 +79,7 @@ def test_create_mail_tools_set():
         "send_response",
         "acknowledge_broadcast",
         "ignore_broadcast",
+        "await_message",
     }
 
 
@@ -98,3 +100,21 @@ def test_convert_call_unknown_tool_raises():
     """
     with pytest.raises(ValueError):
         convert_call_to_mail_message(_call("not_a_tool", {}), sender="a", task_id="t")
+
+
+def test_create_await_message_tool_shape():
+    """
+    The await_message tool exposes an optional reason field for both styles.
+    """
+
+    completions_tool = create_await_message_tool(style="completions")
+    assert completions_tool["function"]["name"] == "await_message"
+    reason_field = completions_tool["function"]["parameters"]["properties"]["reason"]
+    assert "string" in [any_of["type"] for any_of in reason_field["anyOf"]]
+    assert "Optional" in reason_field["description"]
+
+    responses_tool = create_await_message_tool(style="responses")
+    assert responses_tool["name"] == "await_message"
+    responses_reason = responses_tool["parameters"]["properties"]["reason"]
+    assert "string" in [any_of["type"] for any_of in responses_reason["anyOf"]]
+    assert "Optional" in responses_reason["description"]


### PR DESCRIPTION
- New core tool `await_message` takes in an optional `reason: str` and allows for an agent to end its turn within a larger task
- Tool call responses within `mail.core.runtime:MAILRuntime` are now handled more consistently; `status: Literal["success", "error"]` now returned for all tool calls
- Added `await_message` to MAIL spec
- Updated docs and tests accordingly; all tests pass