### PR TITLE
Added client CLI support for mailing list operations

### DIFF
--- a/src/mail/client/docs/reference/admin-panel.md
+++ b/src/mail/client/docs/reference/admin-panel.md
@@ -44,6 +44,16 @@ mail-admin [option]... <command> [argument]...
 - `webhook-patch`: Update an existing webhook by ID on the MAIL server.
 - `webhook-delete`: Delete an existing webhook by ID on the MAIL server.
 
+### Mailing List Operations
+
+- `list-list`: Get all mailing lists on the MAIL server.
+- `list-get`: Get a specific mailing list by address on the MAIL server.
+- `list-post`: Create a new mailing list on the MAIL server.
+- `list-patch` Update an existing mailing list on the MAIL server.
+- `list-delete`: Delete an existing mailing list by address from the MAIL server.
+- `list-member-post`: Add a new member to the existing mailing list on the MAIL server.
+- `list-member-delete`: Remove a member from an existing mailing list on the MAIL server.
+
 ### Utility Commands (same as main CLI)
 
 - `ping`: Attempt to ping the MAIL server at the URL provided.

--- a/src/mail/client/docs/reference/cli.md
+++ b/src/mail/client/docs/reference/cli.md
@@ -28,6 +28,13 @@ mail [option]... <command> [argument]...
 - `swarm-list`: List the MAIL swarms on this server.
 - `swarm-get`: Get a specific MAIL swarm by name on this server.
 
+### Mailing List Helpers
+
+- `lists`: Get the mailing lists on this MAIL server for the authorized user-agent.
+- `list-get`: Get a specific mailing list on this MAIL server by address.
+- `list-subscribe`: Subscribe to an existing mailing list by address on this MAIL server.
+- `list-unsubscribe`: Unsubscribe from an existing mailing list by address on this MAIL server.
+
 ### Utility Commands
 
 - `ping`: Attempt to ping the MAIL server at the URL provided.

--- a/src/mail/client/src/mail_client/admin_panel.py
+++ b/src/mail/client/src/mail_client/admin_panel.py
@@ -12,6 +12,13 @@ from mail_client.commands import (
     cmd_daemon_get,
     cmd_daemon_list,
     cmd_daemon_post,
+    cmd_list_delete,
+    cmd_list_get_admin,
+    cmd_list_list,
+    cmd_list_member_delete,
+    cmd_list_member_post,
+    cmd_list_patch,
+    cmd_list_post,
     cmd_login,
     cmd_ping,
     cmd_swarm_delete,
@@ -346,6 +353,125 @@ def main() -> None:
     )
     webhook_delete_p.add_argument("webhook_id", help="the ID of the webhook to delete")
     webhook_delete_p.set_defaults(func=cmd_webhook_delete, cmd="webhook-delete")
+
+    #
+    # Mailing list helpers
+    #
+    # command `list-list`
+    list_list_d = "get all mailing lists on the MAIL server"
+    list_list_p = subparsers.add_parser(
+        "list-list",
+        aliases=["ll"],
+        prog="mail-admin list-list",
+        help=list_list_d,
+        description=list_list_d,
+    )
+    list_list_p.set_defaults(func=cmd_list_list, cmd="list-list")
+
+    # command `list-get`
+    list_get_d = "get a specific mailing list on the MAIL server by address"
+    list_get_p = subparsers.add_parser(
+        "list-get",
+        aliases=["lg"],
+        prog="mail-admin list-get",
+        help=list_get_d,
+        description=list_get_d,
+    )
+    list_get_p.add_argument(
+        "list_address", help="the address of the mailing list to get"
+    )
+    list_get_p.set_defaults(func=cmd_list_get_admin, cmd="list-get")
+
+    # command `list-post`
+    list_post_d = "create a new mailing list on the MAIL server"
+    list_post_p = subparsers.add_parser(
+        "list-post",
+        aliases=["lp"],
+        prog="mail-admin list-post",
+        help=list_post_d,
+        description=list_post_d,
+    )
+    list_post_p.add_argument("name", help="the name of the new mailing list")
+    list_post_p.add_argument(
+        "swarm_name", help="the name of the swarm to use for this mailing list"
+    )
+    list_post_p.add_argument("owner", help="the MAIL address of the mailing list owner")
+    list_post_p.add_argument(
+        "-m",
+        "--members",
+        nargs="+",
+        default=[],
+        help="the MAIL addresses of members to add to this mailing list (default: %(default)s",
+    )
+    list_post_p.set_defaults(func=cmd_list_post, cmd="list-post")
+
+    # command `list-patch`
+    list_patch_d = "update an existing mailing list on the MAIL server"
+    list_patch_p = subparsers.add_parser(
+        "list-patch",
+        aliases=["lP"],
+        prog="mail-admin list-patch",
+        help=list_patch_d,
+        description=list_patch_d,
+    )
+    list_patch_p.set_defaults(func=cmd_list_patch, cmd="list-patch")
+
+    # command `list-delete`
+    list_delete_d = "delete an existing mailing list on the MAIL server by address"
+    list_delete_p = subparsers.add_parser(
+        "list-delete",
+        aliases=["ld"],
+        prog="mail-admin list-delete",
+        help=list_delete_d,
+        description=list_delete_d,
+    )
+    list_delete_p.add_argument(
+        "list_address", help="the address of the mailing list to delete"
+    )
+    list_delete_p.set_defaults(func=cmd_list_delete, cmd="list-delete")
+
+    # command `list-member-post`
+    list_member_post_d = (
+        "add a new member to an existing mailing list on the MAIL server"
+    )
+    list_member_post_p = subparsers.add_parser(
+        "list-member-post",
+        aliases=["lmp"],
+        prog="mail-admin list-member-post",
+        help=list_member_post_d,
+        description=list_member_post_d,
+    )
+    list_member_post_p.add_argument(
+        "list_address", help="the MAIL address of the mailing list to add a member to"
+    )
+    list_member_post_p.add_argument(
+        "member_address",
+        help="the MAIL address of the member to add to this mailing list",
+    )
+    list_member_post_p.set_defaults(func=cmd_list_member_post, cmd="list-member-post")
+
+    # command `list-member-delete`
+    list_member_delete_d = (
+        "delete a member from an existing mailing list on the MAIL server"
+    )
+    list_member_delete_p = subparsers.add_parser(
+        "list-member-delete",
+        aliases=["lmd"],
+        prog="mail-admin list-member-delete",
+        help=list_member_delete_d,
+        description=list_member_delete_d,
+    )
+    list_member_delete_p.add_argument(
+        "list_address",
+        help="the MAIL address of the mailing list to remove a member from",
+    )
+    list_member_delete_p.add_argument(
+        "member_address",
+        help="the MAIL address of the member to remove from this mailing list",
+    )
+    list_member_delete_p.set_defaults(
+        func=cmd_list_member_delete, cmd="list-member-delete"
+    )
 
     # parse and handle args
     args = parser.parse_args()

--- a/src/mail/client/src/mail_client/cli.py
+++ b/src/mail/client/src/mail_client/cli.py
@@ -9,6 +9,10 @@ from mail_client.commands import (
     cmd_drafts_open,
     cmd_inbox,
     cmd_inbox_open,
+    cmd_list_get,
+    cmd_list_subscribe,
+    cmd_list_unsubscribe,
+    cmd_lists,
     cmd_login,
     cmd_outbox,
     cmd_outbox_open,
@@ -208,6 +212,61 @@ def main() -> None:
     )
     swarm_get_p.add_argument("swarm_name", help="the name of the MAIL swarm to get")
     swarm_get_p.set_defaults(func=cmd_swarm_get, cmd="swarm-get")
+
+    #
+    # Mailing list helpers
+    #
+    # command `lists`
+    lists_d = "get mailing lists on this MAIL server"
+    lists_p = subparsers.add_parser(
+        "lists",
+        prog="mail lists",
+        help=lists_d,
+        description=lists_d,
+    )
+    lists_p.set_defaults(func=cmd_lists, cmd="lists")
+
+    # command `list-get`
+    list_get_d = "get a specific list on this MAIL server by address"
+    list_get_p = subparsers.add_parser(
+        "list-get",
+        aliases=["list", "lg"],
+        prog="mail list-get",
+        help=list_get_d,
+        description=list_get_d,
+    )
+    list_get_p.add_argument(
+        "list_address", help="the address of the mailing list to get"
+    )
+    list_get_p.set_defaults(func=cmd_list_get, cmd="list-get")
+
+    # command `list-subscribe`
+    list_subscribe_d = "subscribe to a mailing list on this server by address"
+    list_subscribe_p = subparsers.add_parser(
+        "list-subscribe",
+        aliases=["ls"],
+        prog="mail list-subscribe",
+        help=list_subscribe_d,
+        description=list_subscribe_d,
+    )
+    list_subscribe_p.add_argument(
+        "list_address", help="the address of the mailing list to subscribe to"
+    )
+    list_subscribe_p.set_defaults(func=cmd_list_subscribe, cmd="list-subscribe")
+
+    # command `list-unsubscribe`
+    list_unsubscribe_d = "unsubscribe from a mailing list on this server by address"
+    list_unsubscribe_p = subparsers.add_parser(
+        "list-unsubscribe",
+        aliases=["lu"],
+        prog="mail list-unsubscribe",
+        help=list_unsubscribe_d,
+        description=list_unsubscribe_d,
+    )
+    list_unsubscribe_p.add_argument(
+        "list_address", help="the address of the mailing list to unsubscribe from"
+    )
+    list_unsubscribe_p.set_defaults(func=cmd_list_unsubscribe, cmd="list-unsubscribe")
 
     # parse and handle args
     args = parser.parse_args()

--- a/src/mail/client/src/mail_client/commands/__init__.py
+++ b/src/mail/client/src/mail_client/commands/__init__.py
@@ -11,7 +11,14 @@ from .drafts import cmd_drafts
 from .drafts_open import cmd_drafts_open
 from .inbox import cmd_inbox
 from .inbox_open import cmd_inbox_open
+from .list_delete import cmd_list_delete
 from .list_get import cmd_list_get
+from .list_get_admin import cmd_list_get_admin
+from .list_list import cmd_list_list
+from .list_member_delete import cmd_list_member_delete
+from .list_member_post import cmd_list_member_post
+from .list_patch import cmd_list_patch
+from .list_post import cmd_list_post
 from .list_subscribe import cmd_list_subscribe
 from .list_unsubscribe import cmd_list_unsubscribe
 from .lists import cmd_lists
@@ -51,7 +58,14 @@ __all__ = [
     "cmd_drafts_open",
     "cmd_inbox",
     "cmd_inbox_open",
+    "cmd_list_delete",
     "cmd_list_get",
+    "cmd_list_get_admin",
+    "cmd_list_list",
+    "cmd_list_member_delete",
+    "cmd_list_member_post",
+    "cmd_list_patch",
+    "cmd_list_post",
     "cmd_list_subscribe",
     "cmd_list_unsubscribe",
     "cmd_lists",

--- a/src/mail/client/src/mail_client/commands/__init__.py
+++ b/src/mail/client/src/mail_client/commands/__init__.py
@@ -11,6 +11,10 @@ from .drafts import cmd_drafts
 from .drafts_open import cmd_drafts_open
 from .inbox import cmd_inbox
 from .inbox_open import cmd_inbox_open
+from .list_get import cmd_list_get
+from .list_subscribe import cmd_list_subscribe
+from .list_unsubscribe import cmd_list_unsubscribe
+from .lists import cmd_lists
 from .login import cmd_login
 from .outbox import cmd_outbox
 from .outbox_open import cmd_outbox_open
@@ -47,6 +51,10 @@ __all__ = [
     "cmd_drafts_open",
     "cmd_inbox",
     "cmd_inbox_open",
+    "cmd_list_get",
+    "cmd_list_subscribe",
+    "cmd_list_unsubscribe",
+    "cmd_lists",
     "cmd_login",
     "cmd_outbox",
     "cmd_outbox_open",

--- a/src/mail/client/src/mail_client/commands/list_delete.py
+++ b/src/mail/client/src/mail_client/commands/list_delete.py
@@ -6,15 +6,14 @@ from argparse import Namespace
 
 import httpx
 from mail_protocol.network.responses import (
-    ListsGetResponse,
+    AdminListDeleteResponse,
 )
 from pydantic import ValidationError
 
 
-def cmd_lists(args: Namespace) -> None:
+def cmd_list_delete(args: Namespace) -> None:
     """
-    Get the list of mailing list addresses on this MAIL server.
-    Only includes the mailing list this user-agent is authorized to access.
+    Delete a specific mailing list by address from the MAIL server.
     """
 
     # 1. check that required env vars are provided
@@ -25,9 +24,9 @@ def cmd_lists(args: Namespace) -> None:
     if MAIL_TOKEN is None:
         raise ValueError("environment variable MAIL_TOKEN is required")
 
-    # 2. Attempt to get the list of mailing lists on the MAIL server
-    response = httpx.get(
-        url=f"{MAIL_SERVER}/lists",
+    # 2. Attempt to delete the specific mailing list by address from the MAIL server
+    response = httpx.delete(
+        url=f"{MAIL_SERVER}/admin/lists/{args.list_address}",
         headers={
             "User-Agent": "Multi-Agent-Interface-Layer-CLI-Client/2.0.0 (github.com/charonlabs/mail)",
             "Authorization": f"Bearer {MAIL_TOKEN}",
@@ -37,16 +36,16 @@ def cmd_lists(args: Namespace) -> None:
     # 3. Parse and validate server response
     if response.status_code != 200:
         raise RuntimeError(
-            f"get lists request to {MAIL_SERVER} failed with status code {response.status_code}"
+            f"delete mailing list request to {MAIL_SERVER} failed with status code {response.status_code}"
         )
 
     response_json = response.json()
     try:
-        response_obj = ListsGetResponse.model_validate(response_json)
+        response_obj = AdminListDeleteResponse.model_validate(response_json)
     except ValidationError as e:
         raise RuntimeError(f"response validation failed: {e}")
 
-    # 4. Print the list of mailing lists
+    # 4. Print the specified mailing list
     match args.output:
         case "json":
             _print_json(response_obj)
@@ -54,12 +53,19 @@ def cmd_lists(args: Namespace) -> None:
             _print_text(response_obj)
 
 
-def _print_json(response_obj: ListsGetResponse) -> None:
+def _print_json(response_obj: AdminListDeleteResponse) -> None:
     print(response_obj.model_dump_json())
 
 
-def _print_text(response_obj: ListsGetResponse) -> None:
-    lists = response_obj.lists
-    print("=== Mailing Lists ===")
-    for list in lists:
-        print(f"{list.get_address()} ({len(list.members)} members)")
+def _print_text(response_obj: AdminListDeleteResponse) -> None:
+    mlist = response_obj.mail_list
+    print("=== Mailing List ===")
+    print(f"List ID: {mlist.list_id}")
+    print(f"Address: {mlist.get_address()}")
+    print(f"Owner: {mlist.owner}")
+    print(f"Members: {mlist.members}")
+    print(f"Visibility: {mlist.policy.visibility}")
+    print(f"Join Policy: {mlist.policy.join_policy}")
+    print(f"Send Policy: {mlist.policy.send_policy}")
+    print(f"Created At: {mlist.created_at}")
+    print(f"Updated At: {mlist.updated_at}")

--- a/src/mail/client/src/mail_client/commands/list_get.py
+++ b/src/mail/client/src/mail_client/commands/list_get.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Addison Kline
+
+import os
+from argparse import Namespace
+
+import httpx
+from mail_protocol.network.responses import (
+    ListGetResponse,
+)
+from pydantic import ValidationError
+
+
+def cmd_list_get(args: Namespace) -> None:
+    """
+    Get a specific mailing list by address on the MAIL server.
+    """
+
+    # 1. check that required env vars are provided
+    MAIL_SERVER = os.getenv("MAIL_SERVER")
+    if MAIL_SERVER is None:
+        raise ValueError("environment variable MAIL_SERVER is required")
+    MAIL_TOKEN = os.getenv("MAIL_TOKEN")
+    if MAIL_TOKEN is None:
+        raise ValueError("environment variable MAIL_TOKEN is required")
+
+    # 2. Attempt to get the specific mailing list by address on the MAIL server
+    response = httpx.get(
+        url=f"{MAIL_SERVER}/lists/{args.list_address}",
+        headers={
+            "User-Agent": "Multi-Agent-Interface-Layer-CLI-Client/2.0.0 (github.com/charonlabs/mail)",
+            "Authorization": f"Bearer {MAIL_TOKEN}",
+        },
+    )
+
+    # 3. Parse and validate server response
+    if response.status_code != 200:
+        raise RuntimeError(
+            f"get mailing list request to {MAIL_SERVER} failed with status code {response.status_code}"
+        )
+
+    response_json = response.json()
+    try:
+        response_obj = ListGetResponse.model_validate(response_json)
+    except ValidationError as e:
+        raise RuntimeError(f"response validation failed: {e}")
+
+    # 4. Print the specified mailing lists
+    match args.output:
+        case "json":
+            _print_json(response_obj)
+        case "text":
+            _print_text(response_obj)
+
+
+def _print_json(response_obj: ListGetResponse) -> None:
+    print(response_obj.model_dump_json())
+
+
+def _print_text(response_obj: ListGetResponse) -> None:
+    mlist = response_obj.mail_list
+    print("=== Mailing List ===")
+    print(f"List ID: {mlist.list_id}")
+    print(f"Address: {mlist.get_address()}")
+    print(f"Owner: {mlist.owner}")
+    print(f"Members: {mlist.members}")
+    print(f"Visibility: {mlist.policy.visibility}")
+    print(f"Join Policy: {mlist.policy.join_policy}")
+    print(f"Send Policy: {mlist.policy.send_policy}")
+    print(f"Created At: {mlist.created_at}")
+    print(f"Updated At: {mlist.updated_at}")

--- a/src/mail/client/src/mail_client/commands/list_get_admin.py
+++ b/src/mail/client/src/mail_client/commands/list_get_admin.py
@@ -6,15 +6,14 @@ from argparse import Namespace
 
 import httpx
 from mail_protocol.network.responses import (
-    ListsGetResponse,
+    AdminListGetResponse,
 )
 from pydantic import ValidationError
 
 
-def cmd_lists(args: Namespace) -> None:
+def cmd_list_get_admin(args: Namespace) -> None:
     """
-    Get the list of mailing list addresses on this MAIL server.
-    Only includes the mailing list this user-agent is authorized to access.
+    Get a specific mailing list by address on the MAIL server.
     """
 
     # 1. check that required env vars are provided
@@ -25,9 +24,9 @@ def cmd_lists(args: Namespace) -> None:
     if MAIL_TOKEN is None:
         raise ValueError("environment variable MAIL_TOKEN is required")
 
-    # 2. Attempt to get the list of mailing lists on the MAIL server
+    # 2. Attempt to get the specific mailing list by address on the MAIL server
     response = httpx.get(
-        url=f"{MAIL_SERVER}/lists",
+        url=f"{MAIL_SERVER}/admin/lists/{args.list_address}",
         headers={
             "User-Agent": "Multi-Agent-Interface-Layer-CLI-Client/2.0.0 (github.com/charonlabs/mail)",
             "Authorization": f"Bearer {MAIL_TOKEN}",
@@ -37,16 +36,16 @@ def cmd_lists(args: Namespace) -> None:
     # 3. Parse and validate server response
     if response.status_code != 200:
         raise RuntimeError(
-            f"get lists request to {MAIL_SERVER} failed with status code {response.status_code}"
+            f"get mailing list request to {MAIL_SERVER} failed with status code {response.status_code}"
         )
 
     response_json = response.json()
     try:
-        response_obj = ListsGetResponse.model_validate(response_json)
+        response_obj = AdminListGetResponse.model_validate(response_json)
     except ValidationError as e:
         raise RuntimeError(f"response validation failed: {e}")
 
-    # 4. Print the list of mailing lists
+    # 4. Print the specified mailing list
     match args.output:
         case "json":
             _print_json(response_obj)
@@ -54,12 +53,19 @@ def cmd_lists(args: Namespace) -> None:
             _print_text(response_obj)
 
 
-def _print_json(response_obj: ListsGetResponse) -> None:
+def _print_json(response_obj: AdminListGetResponse) -> None:
     print(response_obj.model_dump_json())
 
 
-def _print_text(response_obj: ListsGetResponse) -> None:
-    lists = response_obj.lists
-    print("=== Mailing Lists ===")
-    for list in lists:
-        print(f"{list.get_address()} ({len(list.members)} members)")
+def _print_text(response_obj: AdminListGetResponse) -> None:
+    mlist = response_obj.mail_list
+    print("=== Mailing List ===")
+    print(f"List ID: {mlist.list_id}")
+    print(f"Address: {mlist.get_address()}")
+    print(f"Owner: {mlist.owner}")
+    print(f"Members: {mlist.members}")
+    print(f"Visibility: {mlist.policy.visibility}")
+    print(f"Join Policy: {mlist.policy.join_policy}")
+    print(f"Send Policy: {mlist.policy.send_policy}")
+    print(f"Created At: {mlist.created_at}")
+    print(f"Updated At: {mlist.updated_at}")

--- a/src/mail/client/src/mail_client/commands/list_list.py
+++ b/src/mail/client/src/mail_client/commands/list_list.py
@@ -6,15 +6,14 @@ from argparse import Namespace
 
 import httpx
 from mail_protocol.network.responses import (
-    ListsGetResponse,
+    AdminListsGetResponse,
 )
 from pydantic import ValidationError
 
 
-def cmd_lists(args: Namespace) -> None:
+def cmd_list_list(args: Namespace) -> None:
     """
-    Get the list of mailing list addresses on this MAIL server.
-    Only includes the mailing list this user-agent is authorized to access.
+    Get all mailing list addresses on this MAIL server.
     """
 
     # 1. check that required env vars are provided
@@ -27,7 +26,7 @@ def cmd_lists(args: Namespace) -> None:
 
     # 2. Attempt to get the list of mailing lists on the MAIL server
     response = httpx.get(
-        url=f"{MAIL_SERVER}/lists",
+        url=f"{MAIL_SERVER}/admin/lists",
         headers={
             "User-Agent": "Multi-Agent-Interface-Layer-CLI-Client/2.0.0 (github.com/charonlabs/mail)",
             "Authorization": f"Bearer {MAIL_TOKEN}",
@@ -42,7 +41,7 @@ def cmd_lists(args: Namespace) -> None:
 
     response_json = response.json()
     try:
-        response_obj = ListsGetResponse.model_validate(response_json)
+        response_obj = AdminListsGetResponse.model_validate(response_json)
     except ValidationError as e:
         raise RuntimeError(f"response validation failed: {e}")
 
@@ -54,11 +53,11 @@ def cmd_lists(args: Namespace) -> None:
             _print_text(response_obj)
 
 
-def _print_json(response_obj: ListsGetResponse) -> None:
+def _print_json(response_obj: AdminListsGetResponse) -> None:
     print(response_obj.model_dump_json())
 
 
-def _print_text(response_obj: ListsGetResponse) -> None:
+def _print_text(response_obj: AdminListsGetResponse) -> None:
     lists = response_obj.lists
     print("=== Mailing Lists ===")
     for list in lists:

--- a/src/mail/client/src/mail_client/commands/list_member_delete.py
+++ b/src/mail/client/src/mail_client/commands/list_member_delete.py
@@ -6,15 +6,14 @@ from argparse import Namespace
 
 import httpx
 from mail_protocol.network.responses import (
-    ListsGetResponse,
+    ListMemberDeleteResponse,
 )
 from pydantic import ValidationError
 
 
-def cmd_lists(args: Namespace) -> None:
+def cmd_list_member_delete(args: Namespace) -> None:
     """
-    Get the list of mailing list addresses on this MAIL server.
-    Only includes the mailing list this user-agent is authorized to access.
+    Remove a member from a specific mailing list by address on the MAIL server.
     """
 
     # 1. check that required env vars are provided
@@ -25,9 +24,9 @@ def cmd_lists(args: Namespace) -> None:
     if MAIL_TOKEN is None:
         raise ValueError("environment variable MAIL_TOKEN is required")
 
-    # 2. Attempt to get the list of mailing lists on the MAIL server
-    response = httpx.get(
-        url=f"{MAIL_SERVER}/lists",
+    # 2. Attempt to remove the user from the mailing list on the MAIL server
+    response = httpx.delete(
+        url=f"{MAIL_SERVER}/admin/lists/{args.list_address}/members/{args.member_address}",
         headers={
             "User-Agent": "Multi-Agent-Interface-Layer-CLI-Client/2.0.0 (github.com/charonlabs/mail)",
             "Authorization": f"Bearer {MAIL_TOKEN}",
@@ -37,16 +36,16 @@ def cmd_lists(args: Namespace) -> None:
     # 3. Parse and validate server response
     if response.status_code != 200:
         raise RuntimeError(
-            f"get lists request to {MAIL_SERVER} failed with status code {response.status_code}"
+            f"delete mailing list member request to {MAIL_SERVER} failed with status code {response.status_code}"
         )
 
     response_json = response.json()
     try:
-        response_obj = ListsGetResponse.model_validate(response_json)
+        response_obj = ListMemberDeleteResponse.model_validate(response_json)
     except ValidationError as e:
         raise RuntimeError(f"response validation failed: {e}")
 
-    # 4. Print the list of mailing lists
+    # 4. Print the specified mailing list
     match args.output:
         case "json":
             _print_json(response_obj)
@@ -54,12 +53,19 @@ def cmd_lists(args: Namespace) -> None:
             _print_text(response_obj)
 
 
-def _print_json(response_obj: ListsGetResponse) -> None:
+def _print_json(response_obj: ListMemberDeleteResponse) -> None:
     print(response_obj.model_dump_json())
 
 
-def _print_text(response_obj: ListsGetResponse) -> None:
-    lists = response_obj.lists
-    print("=== Mailing Lists ===")
-    for list in lists:
-        print(f"{list.get_address()} ({len(list.members)} members)")
+def _print_text(response_obj: ListMemberDeleteResponse) -> None:
+    mlist = response_obj.mail_list
+    print("=== Mailing List ===")
+    print(f"List ID: {mlist.list_id}")
+    print(f"Address: {mlist.get_address()}")
+    print(f"Owner: {mlist.owner}")
+    print(f"Members: {mlist.members}")
+    print(f"Visibility: {mlist.policy.visibility}")
+    print(f"Join Policy: {mlist.policy.join_policy}")
+    print(f"Send Policy: {mlist.policy.send_policy}")
+    print(f"Created At: {mlist.created_at}")
+    print(f"Updated At: {mlist.updated_at}")

--- a/src/mail/client/src/mail_client/commands/list_member_post.py
+++ b/src/mail/client/src/mail_client/commands/list_member_post.py
@@ -5,16 +5,16 @@ import os
 from argparse import Namespace
 
 import httpx
+from mail_protocol.network.requests import ListMemberPostRequest
 from mail_protocol.network.responses import (
-    ListGetResponse,
+    ListMemberPostResponse,
 )
 from pydantic import ValidationError
 
 
-def cmd_list_get(args: Namespace) -> None:
+def cmd_list_member_post(args: Namespace) -> None:
     """
-    Get a specific mailing list by address on the MAIL server.
-    Must be a mailing list that this user-agent is authorized to access.
+    Add a new member to a specific mailing list by address on the MAIL server.
     """
 
     # 1. check that required env vars are provided
@@ -25,28 +25,32 @@ def cmd_list_get(args: Namespace) -> None:
     if MAIL_TOKEN is None:
         raise ValueError("environment variable MAIL_TOKEN is required")
 
-    # 2. Attempt to get the specific mailing list by address on the MAIL server
-    response = httpx.get(
-        url=f"{MAIL_SERVER}/lists/{args.list_address}",
+    # 2. Attempt to add the member to the mailing list on the MAIL server
+    payload = ListMemberPostRequest(
+        member_address=args.member_address,
+    )
+    response = httpx.post(
+        url=f"{MAIL_SERVER}/admin/lists/{args.list_address}/members",
         headers={
             "User-Agent": "Multi-Agent-Interface-Layer-CLI-Client/2.0.0 (github.com/charonlabs/mail)",
             "Authorization": f"Bearer {MAIL_TOKEN}",
         },
+        json=payload.model_dump(),
     )
 
     # 3. Parse and validate server response
     if response.status_code != 200:
         raise RuntimeError(
-            f"get mailing list request to {MAIL_SERVER} failed with status code {response.status_code}"
+            f"post mailing list member request to {MAIL_SERVER} failed with status code {response.status_code}"
         )
 
     response_json = response.json()
     try:
-        response_obj = ListGetResponse.model_validate(response_json)
+        response_obj = ListMemberPostResponse.model_validate(response_json)
     except ValidationError as e:
         raise RuntimeError(f"response validation failed: {e}")
 
-    # 4. Print the specified mailing lists
+    # 4. Print the specified mailing list
     match args.output:
         case "json":
             _print_json(response_obj)
@@ -54,11 +58,11 @@ def cmd_list_get(args: Namespace) -> None:
             _print_text(response_obj)
 
 
-def _print_json(response_obj: ListGetResponse) -> None:
+def _print_json(response_obj: ListMemberPostResponse) -> None:
     print(response_obj.model_dump_json())
 
 
-def _print_text(response_obj: ListGetResponse) -> None:
+def _print_text(response_obj: ListMemberPostResponse) -> None:
     mlist = response_obj.mail_list
     print("=== Mailing List ===")
     print(f"List ID: {mlist.list_id}")

--- a/src/mail/client/src/mail_client/commands/list_patch.py
+++ b/src/mail/client/src/mail_client/commands/list_patch.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Addison Kline
+
+import os
+from argparse import Namespace
+
+import httpx
+from mail_protocol.network.requests import AdminListPatchRequest
+from mail_protocol.network.responses import (
+    AdminListPatchResponse,
+)
+from pydantic import ValidationError
+
+
+def cmd_list_patch(args: Namespace) -> None:
+    """
+    Update an existing mailing list on the MAIL server.
+    """
+
+    raise NotImplementedError

--- a/src/mail/client/src/mail_client/commands/list_post.py
+++ b/src/mail/client/src/mail_client/commands/list_post.py
@@ -5,16 +5,16 @@ import os
 from argparse import Namespace
 
 import httpx
+from mail_protocol.network.requests import AdminListPostRequest
 from mail_protocol.network.responses import (
-    ListGetResponse,
+    AdminListPostResponse,
 )
 from pydantic import ValidationError
 
 
-def cmd_list_get(args: Namespace) -> None:
+def cmd_list_post(args: Namespace) -> None:
     """
-    Get a specific mailing list by address on the MAIL server.
-    Must be a mailing list that this user-agent is authorized to access.
+    Create a new mailing list on the MAIL server.
     """
 
     # 1. check that required env vars are provided
@@ -25,28 +25,36 @@ def cmd_list_get(args: Namespace) -> None:
     if MAIL_TOKEN is None:
         raise ValueError("environment variable MAIL_TOKEN is required")
 
-    # 2. Attempt to get the specific mailing list by address on the MAIL server
-    response = httpx.get(
-        url=f"{MAIL_SERVER}/lists/{args.list_address}",
+    # 4. Attempt to post the new list to the MAIL server
+    payload = AdminListPostRequest(
+        name=args.name,
+        swarm_name=args.swarm_name,
+        owner=args.owner,
+        members=args.members,
+    )
+    response = httpx.post(
+        url=f"{MAIL_SERVER}/admin/lists",
         headers={
             "User-Agent": "Multi-Agent-Interface-Layer-CLI-Client/2.0.0 (github.com/charonlabs/mail)",
             "Authorization": f"Bearer {MAIL_TOKEN}",
+            "Content-Type": "application/json",
         },
+        json=payload.model_dump(),
     )
 
-    # 3. Parse and validate server response
+    # 4. Parse and validate server response
     if response.status_code != 200:
         raise RuntimeError(
-            f"get mailing list request to {MAIL_SERVER} failed with status code {response.status_code}"
+            f"post list request to {MAIL_SERVER} failed with status code {response.status_code}"
         )
 
     response_json = response.json()
     try:
-        response_obj = ListGetResponse.model_validate(response_json)
+        response_obj = AdminListPostResponse.model_validate(response_json)
     except ValidationError as e:
         raise RuntimeError(f"response validation failed: {e}")
 
-    # 4. Print the specified mailing lists
+    # 5. Print the specified mailing list
     match args.output:
         case "json":
             _print_json(response_obj)
@@ -54,11 +62,11 @@ def cmd_list_get(args: Namespace) -> None:
             _print_text(response_obj)
 
 
-def _print_json(response_obj: ListGetResponse) -> None:
+def _print_json(response_obj: AdminListPostResponse) -> None:
     print(response_obj.model_dump_json())
 
 
-def _print_text(response_obj: ListGetResponse) -> None:
+def _print_text(response_obj: AdminListPostResponse) -> None:
     mlist = response_obj.mail_list
     print("=== Mailing List ===")
     print(f"List ID: {mlist.list_id}")

--- a/src/mail/client/src/mail_client/commands/list_subscribe.py
+++ b/src/mail/client/src/mail_client/commands/list_subscribe.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Addison Kline
+
+import os
+from argparse import Namespace
+
+import httpx
+from mail_protocol.network.responses import (
+    ListMemberPostResponse,
+)
+from pydantic import ValidationError
+
+
+def cmd_list_subscribe(args: Namespace) -> None:
+    """
+    Subscribe to a mailing list on this MAIL server.
+    """
+
+    # 1. check that required env vars are provided
+    MAIL_SERVER = os.getenv("MAIL_SERVER")
+    if MAIL_SERVER is None:
+        raise ValueError("environment variable MAIL_SERVER is required")
+    MAIL_TOKEN = os.getenv("MAIL_TOKEN")
+    if MAIL_TOKEN is None:
+        raise ValueError("environment variable MAIL_TOKEN is required")
+
+    # 2. Attempt to subscribe to a specific mailing list on the MAIL server
+    response = httpx.post(
+        url=f"{MAIL_SERVER}/lists/{args.list_address}/subscribe",
+        headers={
+            "User-Agent": "Multi-Agent-Interface-Layer-CLI-Client/2.0.0 (github.com/charonlabs/mail)",
+            "Authorization": f"Bearer {MAIL_TOKEN}",
+        },
+    )
+
+    # 3. Parse and validate server response
+    if response.status_code != 200:
+        raise RuntimeError(
+            f"post list subscribe request to {MAIL_SERVER} failed with status code {response.status_code}"
+        )
+
+    response_json = response.json()
+    try:
+        response_obj = ListMemberPostResponse.model_validate(response_json)
+    except ValidationError as e:
+        raise RuntimeError(f"response validation failed: {e}")
+
+    # 4. Print the mailing list subscribe response
+    match args.output:
+        case "json":
+            _print_json(response_obj)
+        case "text":
+            _print_text(response_obj)
+
+
+def _print_json(response_obj: ListMemberPostResponse) -> None:
+    print(response_obj.model_dump_json())
+
+
+def _print_text(response_obj: ListMemberPostResponse) -> None:
+    mlist = response_obj.mail_list
+    print("=== Mailing List ===")
+    print(f"List ID: {mlist.list_id}")
+    print(f"Address: {mlist.get_address()}")
+    print(f"Owner: {mlist.owner}")
+    print(f"Members: {mlist.members}")
+    print(f"Visibility: {mlist.policy.visibility}")
+    print(f"Join Policy: {mlist.policy.join_policy}")
+    print(f"Send Policy: {mlist.policy.send_policy}")
+    print(f"Created At: {mlist.created_at}")
+    print(f"Updated At: {mlist.updated_at}")

--- a/src/mail/client/src/mail_client/commands/list_unsubscribe.py
+++ b/src/mail/client/src/mail_client/commands/list_unsubscribe.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Addison Kline
+
+import os
+from argparse import Namespace
+
+import httpx
+from mail_protocol.network.responses import (
+    ListMemberDeleteResponse,
+)
+from pydantic import ValidationError
+
+
+def cmd_list_unsubscribe(args: Namespace) -> None:
+    """
+    Unsubscribe from a mailing list on this MAIL server.
+    """
+
+    # 1. check that required env vars are provided
+    MAIL_SERVER = os.getenv("MAIL_SERVER")
+    if MAIL_SERVER is None:
+        raise ValueError("environment variable MAIL_SERVER is required")
+    MAIL_TOKEN = os.getenv("MAIL_TOKEN")
+    if MAIL_TOKEN is None:
+        raise ValueError("environment variable MAIL_TOKEN is required")
+
+    # 2. Attempt to unsubscribe from a specific mailing list on the MAIL server
+    response = httpx.post(
+        url=f"{MAIL_SERVER}/lists/{args.list_address}/unsubscribe",
+        headers={
+            "User-Agent": "Multi-Agent-Interface-Layer-CLI-Client/2.0.0 (github.com/charonlabs/mail)",
+            "Authorization": f"Bearer {MAIL_TOKEN}",
+        },
+    )
+
+    # 3. Parse and validate server response
+    if response.status_code != 200:
+        raise RuntimeError(
+            f"post list subscribe request to {MAIL_SERVER} failed with status code {response.status_code}"
+        )
+
+    response_json = response.json()
+    try:
+        response_obj = ListMemberDeleteResponse.model_validate(response_json)
+    except ValidationError as e:
+        raise RuntimeError(f"response validation failed: {e}")
+
+    # 4. Print the mailing list subscribe response
+    match args.output:
+        case "json":
+            _print_json(response_obj)
+        case "text":
+            _print_text(response_obj)
+
+
+def _print_json(response_obj: ListMemberDeleteResponse) -> None:
+    print(response_obj.model_dump_json())
+
+
+def _print_text(response_obj: ListMemberDeleteResponse) -> None:
+    mlist = response_obj.mail_list
+    print("=== Mailing List ===")
+    print(f"List ID: {mlist.list_id}")
+    print(f"Address: {mlist.get_address()}")
+    print(f"Owner: {mlist.owner}")
+    print(f"Members: {mlist.members}")
+    print(f"Visibility: {mlist.policy.visibility}")
+    print(f"Join Policy: {mlist.policy.join_policy}")
+    print(f"Send Policy: {mlist.policy.send_policy}")
+    print(f"Created At: {mlist.created_at}")
+    print(f"Updated At: {mlist.updated_at}")

--- a/src/mail/client/src/mail_client/commands/lists.py
+++ b/src/mail/client/src/mail_client/commands/lists.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Addison Kline
+
+import os
+from argparse import Namespace
+
+import httpx
+from mail_protocol.network.responses import (
+    ListsGetResponse,
+)
+from pydantic import ValidationError
+
+
+def cmd_lists(args: Namespace) -> None:
+    """
+    Get the list of mailing list addresses on this MAIL server.
+    """
+
+    # 1. check that required env vars are provided
+    MAIL_SERVER = os.getenv("MAIL_SERVER")
+    if MAIL_SERVER is None:
+        raise ValueError("environment variable MAIL_SERVER is required")
+    MAIL_TOKEN = os.getenv("MAIL_TOKEN")
+    if MAIL_TOKEN is None:
+        raise ValueError("environment variable MAIL_TOKEN is required")
+
+    # 2. Attempt to get the list of mailing lists on the MAIL server
+    response = httpx.get(
+        url=f"{MAIL_SERVER}/lists",
+        headers={
+            "User-Agent": "Multi-Agent-Interface-Layer-CLI-Client/2.0.0 (github.com/charonlabs/mail)",
+            "Authorization": f"Bearer {MAIL_TOKEN}",
+        },
+    )
+
+    # 3. Parse and validate server response
+    if response.status_code != 200:
+        raise RuntimeError(
+            f"get lists request to {MAIL_SERVER} failed with status code {response.status_code}"
+        )
+
+    response_json = response.json()
+    try:
+        response_obj = ListsGetResponse.model_validate(response_json)
+    except ValidationError as e:
+        raise RuntimeError(f"response validation failed: {e}")
+
+    # 4. Print the list of mailing lists
+    match args.output:
+        case "json":
+            _print_json(response_obj)
+        case "text":
+            _print_text(response_obj)
+
+
+def _print_json(response_obj: ListsGetResponse) -> None:
+    print(response_obj.model_dump_json())
+
+
+def _print_text(response_obj: ListsGetResponse) -> None:
+    lists = response_obj.lists
+    print("=== Mailing Lists ===")
+    for list in lists:
+        print(f"{list.get_address()} ({len(list.members)} members)")

--- a/src/mail/protocol/src/mail_protocol/network/responses.py
+++ b/src/mail/protocol/src/mail_protocol/network/responses.py
@@ -562,7 +562,7 @@ class ListGetResponse(BaseModel):
 
 class ListMemberPostResponse(BaseModel):
     """
-    Corresponds to `POST /lists/{list_address}/members` and
+    Corresponds to `POST /lists/{list_address}/subscribe` and
     `POST /admin/lists/{list_address}/members`. The updated list with
     the member appended (idempotent — re-adding an existing member is
     a no-op).
@@ -574,7 +574,8 @@ class ListMemberPostResponse(BaseModel):
 
 class ListMemberDeleteResponse(BaseModel):
     """
-    Corresponds to `DELETE /lists/{list_address}/members/{member_address}`.
+    Corresponds to `POST /lists/{list_address}/unsubscribe`
+    and `DELETE /lists/{list_address}/members/{member_address}`.
     The updated list with the member removed (idempotent — removing a
     non-member is a no-op).
     """

--- a/src/mail/server/src/mail_server/routers/lists.py
+++ b/src/mail/server/src/mail_server/routers/lists.py
@@ -91,9 +91,7 @@ async def admin_get_list(request: Request) -> AdminListGetResponse:
     admin = await validate_admin(backend=backend, request=request)
     list_address = request.path_params.get("list_address")
     try:
-        result = await backend.admin_get_list(
-            admin=admin, list_address=list_address
-        )
+        result = await backend.admin_get_list(admin=admin, list_address=list_address)
     except ValueError:
         raise HTTPException(status_code=404, detail="list not found")
     return AdminListGetResponse(mail_list=result, metadata={})
@@ -146,9 +144,7 @@ async def admin_delete_list(request: Request) -> AdminListDeleteResponse:
     admin = await validate_admin(backend=backend, request=request)
     list_address = request.path_params.get("list_address")
     try:
-        result = await backend.admin_delete_list(
-            admin=admin, list_address=list_address
-        )
+        result = await backend.admin_delete_list(admin=admin, list_address=list_address)
     except ValueError:
         raise HTTPException(status_code=404, detail="list not found")
     return AdminListDeleteResponse(mail_list=result, metadata={})
@@ -235,7 +231,7 @@ async def get_list(request: Request) -> ListGetResponse:
 
 
 @public_router.post(
-    "/{list_address}/members",
+    "/{list_address}/subscribe",
     summary="Subscribe to a MAIL list",
     response_model=ListMemberPostResponse,
 )
@@ -252,8 +248,7 @@ async def subscribe(request: Request) -> ListMemberPostResponse:
         raise HTTPException(
             status_code=403,
             detail=(
-                "subscribe is self-only; use the admin endpoint to add "
-                "another member."
+                "subscribe is self-only; use the admin endpoint to add another member."
             ),
         )
 
@@ -278,25 +273,16 @@ async def subscribe(request: Request) -> ListMemberPostResponse:
     return ListMemberPostResponse(mail_list=result, metadata={})
 
 
-@public_router.delete(
-    "/{list_address}/members/{member_address}",
-    summary="Leave a MAIL list",
+@public_router.post(
+    "/{list_address}/unsubscribe",
+    summary="Unsubscribe from a MAIL list",
     response_model=ListMemberDeleteResponse,
 )
 async def unsubscribe(request: Request) -> ListMemberDeleteResponse:
     backend = request.app.state.backend
     user_agent = await validate_user_agent(backend=backend, request=request)
     list_address = request.path_params.get("list_address")
-    member_address = request.path_params.get("member_address")
-
-    if member_address != user_agent.get_address():
-        raise HTTPException(
-            status_code=403,
-            detail=(
-                "unsubscribe is self-only; use the admin endpoint to "
-                "remove another member."
-            ),
-        )
+    member_address = user_agent.get_address()
 
     try:
         result = await backend.remove_list_member(


### PR DESCRIPTION
- Added new `mail` CLI commands for scoped mailing list endpoints
- Added new `mail-admin` CLI commands for admin-level mailing list CRUD endpoints
- Updated `mail-client` reference docs accordingly