### PR TITLE
Improved CLIs for `mail`, `mail-admin`, `mail-server`, and `mail-daemon`

### DIFF
--- a/src/mail/client/src/mail_client/admin_panel.py
+++ b/src/mail/client/src/mail_client/admin_panel.py
@@ -3,6 +3,8 @@
 
 import argparse
 
+from mail_protocol.cli_help import add_hidden_subparsers, make_arg_parser
+
 from mail_client.commands import (
     cmd_agent_delete,
     cmd_agent_get,
@@ -35,13 +37,88 @@ from mail_client.commands import (
     cmd_whoami,
 )
 
+COMMAND_GROUPS = [
+    (
+        "Utility",
+        [
+            ("ping (p)", "Ping a MAIL server."),
+            ("login (l)", "Log into a MAIL server."),
+            ("whoami (me, id)", "Show authenticated user-agent info."),
+        ],
+    ),
+    (
+        "Agents",
+        [
+            ("agent-list (al)", "List agents."),
+            ("agent-get (ag)", "Get an agent by local address."),
+            ("agent-post (ap)", "Create an agent."),
+            ("agent-delete (ad)", "Delete an agent."),
+        ],
+    ),
+    (
+        "Daemons",
+        [
+            ("daemon-list (dl)", "List daemons."),
+            ("daemon-get (dg)", "Get a daemon by local address."),
+            ("daemon-post (dp)", "Create daemon credentials."),
+            ("daemon-delete (dd)", "Delete daemon credentials."),
+        ],
+    ),
+    (
+        "Users",
+        [
+            ("user-list (ul)", "List users."),
+            ("user-get (ug)", "Get a user by ID."),
+            ("user-post (up)", "Create a user."),
+            ("user-delete (ud)", "Delete a user."),
+        ],
+    ),
+    (
+        "Swarms",
+        [
+            ("swarm-post (sp)", "Create a swarm."),
+            ("swarm-delete (sd)", "Delete a swarm by name."),
+        ],
+    ),
+    (
+        "Webhooks",
+        [
+            ("webhook-list (wl)", "List webhooks."),
+            ("webhook-get (wg)", "Get a webhook by ID."),
+            ("webhook-post (wp)", "Create a webhook."),
+            ("webhook-patch (wP)", "Update a webhook."),
+            ("webhook-delete (wd)", "Delete a webhook."),
+        ],
+    ),
+    (
+        "Mailing Lists",
+        [
+            ("list-list (ll)", "List mailing lists."),
+            ("list-get (lg)", "Get a mailing list by address."),
+            ("list-post (lp)", "Create a mailing list."),
+            ("list-patch (lP)", "Update a mailing list."),
+            ("list-delete (ld)", "Delete a mailing list."),
+            ("list-member-post (lmp)", "Add a list member."),
+            ("list-member-delete (lmd)", "Remove a list member."),
+        ],
+    ),
+]
 
-def main() -> None:
-    parser = argparse.ArgumentParser(
+EXAMPLES = [
+    "mail-admin login",
+    "mail-admin agent-list",
+    "mail-admin user-post <user-id>",
+    "mail-admin webhook-list",
+]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = make_arg_parser(
         prog="mail-admin",
         usage="mail-admin [option]... <command> [argument]...",
         description="A Python CLI client admin panel for the Multi-Agent Interface Layer (MAIL)",
-        epilog="Copyright (c) 2026 Addison Kline",
+        command_groups=COMMAND_GROUPS,
+        examples=EXAMPLES,
     )
     parser.add_argument(
         "-o",
@@ -50,14 +127,14 @@ def main() -> None:
         default="text",
         help="the output style for this CLI command (default: %(default)s)",
     )
-    subparsers = parser.add_subparsers(title="commands")
+    subparsers = add_hidden_subparsers(parser)
 
     # command `ping`
     ping_d = "ping a MAIL server"
     ping_p = subparsers.add_parser(
         "ping",
         aliases=["p"],
-        prog="mail ping",
+        prog="mail-admin ping",
         help=ping_d,
         description=ping_d,
     )
@@ -66,7 +143,11 @@ def main() -> None:
     # command `login`
     login_d = "log into a MAIL server"
     login_p = subparsers.add_parser(
-        "login", aliases=["l"], prog="mail login", help=login_d, description=login_d
+        "login",
+        aliases=["l"],
+        prog="mail-admin login",
+        help=login_d,
+        description=login_d,
     )
     login_p.set_defaults(func=cmd_login, cmd="login")
 
@@ -75,7 +156,7 @@ def main() -> None:
     whoami_p = subparsers.add_parser(
         "whoami",
         aliases=["me", "id"],
-        prog="mail whoami",
+        prog="mail-admin whoami",
         help=whoami_d,
         description=whoami_d,
     )
@@ -401,7 +482,7 @@ def main() -> None:
         "--members",
         nargs="+",
         default=[],
-        help="the MAIL addresses of members to add to this mailing list (default: %(default)s",
+        help="the MAIL addresses of members to add to this mailing list (default: %(default)s)",
     )
     list_post_p.set_defaults(func=cmd_list_post, cmd="list-post")
 
@@ -473,7 +554,11 @@ def main() -> None:
         func=cmd_list_member_delete, cmd="list-member-delete"
     )
 
-    # parse and handle args
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
     args = parser.parse_args()
 
     try:

--- a/src/mail/client/src/mail_client/cli.py
+++ b/src/mail/client/src/mail_client/cli.py
@@ -2,6 +2,9 @@
 # Copyright (c) 2026 Addison Kline
 
 import argparse
+import contextlib
+import io
+from collections.abc import Callable
 
 from mail_protocol.cli_help import add_hidden_subparsers, make_arg_parser
 
@@ -26,6 +29,35 @@ from mail_client.commands import (
     cmd_trash_open,
     cmd_whoami,
 )
+
+MARKDOWN_FIELD_LABELS = {
+    "Address",
+    "Agents",
+    "Body",
+    "Created At",
+    "Delivered At",
+    "Delivered By",
+    "Description",
+    "Draft ID",
+    "Join Policy",
+    "Keywords",
+    "List ID",
+    "Members",
+    "Message ID",
+    "Name",
+    "Owner",
+    "Received At",
+    "Recipient(s)",
+    "Send Policy",
+    "Sender",
+    "Sent At",
+    "Sent By",
+    "Subject",
+    "Trashed At",
+    "Type",
+    "Updated At",
+    "Visibility",
+}
 
 COMMAND_GROUPS = [
     (
@@ -88,7 +120,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "-o",
         "--output",
-        choices=["text", "json"],
+        choices=["text", "json", "markdown"],
         default="text",
         help="the output style for this CLI command (default: %(default)s)",
     )
@@ -335,7 +367,83 @@ def main() -> None:
         exit(1)
 
     try:
-        func(args)
+        _run_command(func, args)
     except Exception as e:
         print(f"command {args.cmd} failed: {e}")
         exit(1)
+
+
+def _run_command(
+    func: Callable[[argparse.Namespace], None], args: argparse.Namespace
+) -> None:
+    if args.output != "markdown":
+        func(args)
+        return
+
+    args.output = "text"
+    stdout = io.StringIO()
+    with contextlib.redirect_stdout(stdout):
+        func(args)
+
+    print(_text_to_markdown(stdout.getvalue()), end="")
+
+
+def _text_to_markdown(text: str) -> str:
+    lines = text.splitlines()
+    markdown_lines: list[str] = []
+    seen_heading = False
+    in_section = False
+    in_body = False
+
+    for line in lines:
+        if line.startswith("=== ") and line.endswith(" ==="):
+            if in_body:
+                markdown_lines.append("```")
+                markdown_lines.append("")
+                in_body = False
+
+            title = line.removeprefix("=== ").removesuffix(" ===")
+            heading_prefix = "##" if seen_heading else "#"
+            markdown_lines.append(f"{heading_prefix} {title}")
+            seen_heading = True
+            in_section = True
+            continue
+
+        if in_body:
+            markdown_lines.append(line)
+            continue
+
+        if not line:
+            markdown_lines.append("")
+            continue
+
+        label, separator, value = line.partition(":")
+        if separator and label in MARKDOWN_FIELD_LABELS:
+            if label == "Body":
+                markdown_lines.append("- **Body:**")
+                markdown_lines.append("")
+                markdown_lines.append("```")
+                if value.lstrip():
+                    markdown_lines.append(value.lstrip())
+                in_body = True
+                continue
+
+            markdown_lines.append(f"- **{label}:** {value.lstrip()}")
+            continue
+
+        if line.startswith("- "):
+            markdown_lines.append(line)
+            continue
+
+        if in_section:
+            markdown_lines.append(f"- {line}")
+        else:
+            markdown_lines.append(line)
+
+    if in_body:
+        markdown_lines.append("```")
+
+    if not markdown_lines:
+        return ""
+
+    return "\n".join(markdown_lines) + "\n"

--- a/src/mail/client/src/mail_client/cli.py
+++ b/src/mail/client/src/mail_client/cli.py
@@ -3,6 +3,8 @@
 
 import argparse
 
+from mail_protocol.cli_help import add_hidden_subparsers, make_arg_parser
+
 from mail_client.commands import (
     cmd_compose,
     cmd_drafts,
@@ -25,13 +27,63 @@ from mail_client.commands import (
     cmd_whoami,
 )
 
+COMMAND_GROUPS = [
+    (
+        "Utility",
+        [
+            ("ping (p)", "Ping a MAIL server."),
+            ("login (l)", "Log into a MAIL server."),
+            ("whoami (me, id)", "Show authenticated user-agent info."),
+        ],
+    ),
+    (
+        "Messaging",
+        [
+            ("compose (c)", "Draft a new MAIL message."),
+            ("send (s)", "Send a drafted message."),
+            ("inbox (i)", "List your inbox messages."),
+            ("inbox-open (open, o)", "Open an inbox message by ID."),
+            ("outbox (O)", "List your sent messages."),
+            ("outbox-open (Oopen, Oo)", "Open an outbox message by ID."),
+            ("drafts (d)", "List message drafts."),
+            ("drafts-open (do)", "Open a draft by ID."),
+            ("trash (t)", "List trashed messages."),
+            ("trash-open (to)", "Open a trashed message by ID."),
+        ],
+    ),
+    (
+        "Swarms",
+        [
+            ("swarm-list (swarms, sl)", "List swarms on the server."),
+            ("swarm-get (swarm, sg)", "Get a swarm by name."),
+        ],
+    ),
+    (
+        "Mailing Lists",
+        [
+            ("lists", "List mailing lists."),
+            ("list-get (list, lg)", "Get a list by address."),
+            ("list-subscribe (ls)", "Subscribe to a list."),
+            ("list-unsubscribe (lu)", "Unsubscribe from a list."),
+        ],
+    ),
+]
 
-def main() -> None:
-    parser = argparse.ArgumentParser(
+EXAMPLES = [
+    "mail login",
+    'mail compose "Status update" "The migration is complete."',
+    "mail send <draft-id> user@example",
+    "mail inbox-open <message-id>",
+]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = make_arg_parser(
         prog="mail",
         usage="mail [option...] <command> [argument...]",
         description="The Python CLI client for the Multi-Agent Interface Layer (MAIL)",
-        epilog="Copyright (c) 2026 Addison Kline",
+        command_groups=COMMAND_GROUPS,
+        examples=EXAMPLES,
     )
     parser.add_argument(
         "-o",
@@ -40,7 +92,7 @@ def main() -> None:
         default="text",
         help="the output style for this CLI command (default: %(default)s)",
     )
-    subparsers = parser.add_subparsers(title="commands")
+    subparsers = add_hidden_subparsers(parser)
 
     #
     # Utility commands
@@ -268,7 +320,11 @@ def main() -> None:
     )
     list_unsubscribe_p.set_defaults(func=cmd_list_unsubscribe, cmd="list-unsubscribe")
 
-    # parse and handle args
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
     args = parser.parse_args()
 
     try:

--- a/src/mail/daemon/pyproject.toml
+++ b/src/mail/daemon/pyproject.toml
@@ -9,6 +9,7 @@ authors = [
 requires-python = ">=3.12"
 dependencies = [
     "httpx>=0.28.1",
+    "mail-protocol>=2.0.0",
     "pydantic>=2.11.7",
 ]
 

--- a/src/mail/daemon/src/mail_daemon/cli.py
+++ b/src/mail/daemon/src/mail_daemon/cli.py
@@ -3,33 +3,47 @@
 
 import argparse
 
+from mail_protocol.cli_help import make_arg_parser
+
 from mail_daemon.logger import init_logger
 from mail_daemon.maild.api import run_daemon
 
+EXAMPLES = [
+    "mail-daemon",
+    "mail-daemon --log-level-console debug",
+    "mail-daemon --log-level-file warning",
+]
 
-def main() -> None:
-    parser = argparse.ArgumentParser(
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = make_arg_parser(
         prog="mail-daemon",
         usage="mail-daemon [option]...",
         description="Multi-Agent Interface Layer (MAIL) daemon implementation in Python",
-        epilog="Copyright (c) 2026 Addison Kline",
+        examples=EXAMPLES,
     )
     parser.add_argument(
         "-llf",
-        "-log-level-file",
+        "--log-level-file",
+        metavar="LEVEL",
         choices=["debug", "info", "warning", "error", "critical"],
         default="info",
-        help="the minimum log level to write to the daemon log file (default: %(default)s)",
+        help="file log level (default: %(default)s)",
     )
     parser.add_argument(
         "-llc",
         "--log-level-console",
+        metavar="LEVEL",
         choices=["debug", "info", "warning", "error", "critical"],
         default="info",
-        help="the minimum log level to write to the console (default: %(default)s)",
+        help="console log level (default: %(default)s)",
     )
 
-    # parse and handle args
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
     args = parser.parse_args()
 
     init_logger(log_level_file=args.llf, log_level_console=args.log_level_console)

--- a/src/mail/protocol/src/mail_protocol/cli_help.py
+++ b/src/mail/protocol/src/mail_protocol/cli_help.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Addison Kline
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Sequence
+
+CommandHelp = tuple[str, str]
+CommandGroup = tuple[str, Sequence[CommandHelp]]
+
+
+class MAILHelpFormatter(
+    argparse.ArgumentDefaultsHelpFormatter,
+    argparse.RawDescriptionHelpFormatter,
+):
+    """Readable defaults for MAIL command-line help."""
+
+    def __init__(self, prog: str):
+        super().__init__(prog, max_help_position=32, width=100)
+
+
+def build_epilog(
+    *,
+    command_groups: Sequence[CommandGroup] | None = None,
+    examples: Sequence[str] | None = None,
+    footer: str | None = "Copyright (c) 2026 Addison Kline",
+) -> str | None:
+    sections: list[str] = []
+
+    if command_groups:
+        lines = ["Commands:"]
+        for title, commands in command_groups:
+            lines.append(f"  {title}:")
+            width = max(len(name) for name, _description in commands)
+            for name, description in commands:
+                lines.append(f"    {name.ljust(width)}  {description}")
+        sections.append("\n".join(lines))
+
+    if examples:
+        lines = ["Examples:"]
+        lines.extend(f"  {example}" for example in examples)
+        sections.append("\n".join(lines))
+
+    if footer:
+        sections.append(footer)
+
+    if not sections:
+        return None
+
+    return "\n\n".join(sections)
+
+
+def make_arg_parser(
+    *,
+    prog: str,
+    usage: str,
+    description: str,
+    command_groups: Sequence[CommandGroup] | None = None,
+    examples: Sequence[str] | None = None,
+) -> argparse.ArgumentParser:
+    return argparse.ArgumentParser(
+        prog=prog,
+        usage=usage,
+        description=description,
+        epilog=build_epilog(command_groups=command_groups, examples=examples),
+        formatter_class=MAILHelpFormatter,
+    )
+
+
+def add_hidden_subparsers(parser: argparse.ArgumentParser):
+    return parser.add_subparsers(
+        metavar="<command>",
+        help=argparse.SUPPRESS,
+    )

--- a/src/mail/server/src/mail_server/cli.py
+++ b/src/mail/server/src/mail_server/cli.py
@@ -3,27 +3,34 @@
 
 import argparse
 
+from mail_protocol.cli_help import make_arg_parser
 from mail_protocol.constants import MAIL_DEFAULT_HOST, MAIL_DEFAULT_PORT
 
-from mail_server.server import run_server
+EXAMPLES = [
+    "mail-server",
+    "mail-server --host 0.0.0.0 --port 8865",
+    "mail-server --backend memory",
+]
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser(
+def build_parser() -> argparse.ArgumentParser:
+    parser = make_arg_parser(
         prog="mail-server",
         usage="mail-server [option]...",
         description="The Python/FastAPI server for the Multi-Agent Interface Layer (MAIL)",
-        epilog="Copyright (c) 2026 Addison Kline",
+        examples=EXAMPLES,
     )
     parser.add_argument(
         "-H",
         "--host",
+        metavar="HOST",
         default=MAIL_DEFAULT_HOST,
         help="the IP address to bind to (default: %(default)s)",
     )
     parser.add_argument(
         "-p",
         "--port",
+        metavar="PORT",
         default=MAIL_DEFAULT_PORT,
         type=int,
         help="the port for the server to listen on (default: %(default)s)",
@@ -31,12 +38,19 @@ def main() -> None:
     parser.add_argument(
         "-b",
         "--backend",
+        metavar="BACKEND",
         choices=["memory"],
         default="memory",
         help="the MAIL server backend to use (default: %(default)s)",
     )
 
-    # parse and handle args
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
     args = parser.parse_args()
+
+    from mail_server.server import run_server
 
     run_server(args)

--- a/tests/unit/test_cli_help.py
+++ b/tests/unit/test_cli_help.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Addison Kline
+
+from __future__ import annotations
+
+import pytest
+from mail_client.admin_panel import build_parser as build_admin_parser
+from mail_client.cli import build_parser as build_mail_parser
+from mail_daemon.cli import build_parser as build_daemon_parser
+from mail_server.cli import build_parser as build_server_parser
+
+
+def test_mail_help_uses_categorized_command_sections() -> None:
+    help_text = build_mail_parser().format_help()
+
+    assert "Commands:\n  Utility:" in help_text
+    assert "  Messaging:" in help_text
+    assert "  Swarms:" in help_text
+    assert "  Mailing Lists:" in help_text
+    assert "{ping,p,login" not in help_text
+    assert 'mail compose "Status update"' in help_text
+
+
+def test_mail_admin_help_uses_categorized_command_sections() -> None:
+    help_text = build_admin_parser().format_help()
+
+    assert "Commands:\n  Utility:" in help_text
+    assert "  Agents:" in help_text
+    assert "  Daemons:" in help_text
+    assert "  Webhooks:" in help_text
+    assert "  Mailing Lists:" in help_text
+    assert "{ping,p,login" not in help_text
+    assert "mail-admin agent-list" in help_text
+
+
+def test_mail_admin_subcommand_help_uses_admin_prog(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    parser = build_admin_parser()
+
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args(["ping", "--help"])
+
+    assert exc_info.value.code == 0
+    assert "usage: mail-admin ping" in capsys.readouterr().out
+
+
+def test_mail_server_help_does_not_import_runtime_configuration() -> None:
+    help_text = build_server_parser().format_help()
+
+    assert "usage: mail-server [option]..." in help_text
+    assert "--host HOST" in help_text
+    assert "mail-server --host 0.0.0.0 --port 8865" in help_text
+
+
+def test_mail_daemon_help_has_readable_log_options() -> None:
+    help_text = build_daemon_parser().format_help()
+
+    assert "--log-level-file LEVEL" in help_text
+    assert "-llf LEVEL, -log-level-file LEVEL" not in help_text
+    assert "--log-level-console LEVEL" in help_text
+    assert "mail-daemon --log-level-console debug" in help_text

--- a/tests/unit/test_cli_help.py
+++ b/tests/unit/test_cli_help.py
@@ -3,9 +3,17 @@
 
 from __future__ import annotations
 
+from argparse import Namespace
+
 import pytest
 from mail_client.admin_panel import build_parser as build_admin_parser
-from mail_client.cli import build_parser as build_mail_parser
+from mail_client.cli import (
+    _run_command,
+    _text_to_markdown,
+)
+from mail_client.cli import (
+    build_parser as build_mail_parser,
+)
 from mail_daemon.cli import build_parser as build_daemon_parser
 from mail_server.cli import build_parser as build_server_parser
 
@@ -60,3 +68,94 @@ def test_mail_daemon_help_has_readable_log_options() -> None:
     assert "-llf LEVEL, -log-level-file LEVEL" not in help_text
     assert "--log-level-console LEVEL" in help_text
     assert "mail-daemon --log-level-console debug" in help_text
+
+
+def test_mail_parser_accepts_markdown_output() -> None:
+    args = build_mail_parser().parse_args(["--output", "markdown", "ping"])
+
+    assert args.output == "markdown"
+
+
+def test_text_to_markdown_converts_structured_text() -> None:
+    text = (
+        "=== Draft ===\n"
+        "Draft ID: draft-123\n"
+        "Body:\n"
+        "hello world\n"
+        "line: with colon\n"
+        "=== Entry Data ===\n"
+        "Sent At: None\n"
+    )
+
+    assert _text_to_markdown(text) == (
+        "# Draft\n"
+        "- **Draft ID:** draft-123\n"
+        "- **Body:**\n"
+        "\n"
+        "```\n"
+        "hello world\n"
+        "line: with colon\n"
+        "```\n"
+        "\n"
+        "## Entry Data\n"
+        "- **Sent At:** None\n"
+    )
+
+
+def test_text_to_markdown_preserves_mailbox_summary_timestamps() -> None:
+    text = (
+        "=== Inbox ===\n"
+        "2026-06-09T14:23:45+00:00 | msg-123 | [agent@swarm@host] Subject (42 characters)\n"
+    )
+
+    assert _text_to_markdown(text) == (
+        "# Inbox\n"
+        "- 2026-06-09T14:23:45+00:00 | msg-123 | [agent@swarm@host] Subject (42 characters)\n"
+    )
+
+
+def test_text_to_markdown_preserves_recipient_address_prefixes() -> None:
+    text = (
+        "=== Message ===\n"
+        "Recipient(s):\n"
+        "- user:alice@example.com\n"
+        "- daemon:worker@example.com\n"
+    )
+
+    assert _text_to_markdown(text) == (
+        "# Message\n"
+        "- **Recipient(s):** \n"
+        "- user:alice@example.com\n"
+        "- daemon:worker@example.com\n"
+    )
+
+
+def test_text_to_markdown_preserves_list_addresses_and_swarm_summaries() -> None:
+    text = (
+        "=== Mailing Lists ===\n"
+        "list:dev@example@host (3 members)\n"
+        "=== Swarms ===\n"
+        "[example] (2 agents): [weather, math]\n"
+    )
+
+    assert _text_to_markdown(text) == (
+        "# Mailing Lists\n"
+        "- list:dev@example@host (3 members)\n"
+        "## Swarms\n"
+        "- [example] (2 agents): [weather, math]\n"
+    )
+
+
+def test_run_command_renders_markdown_from_text_output(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def command(args: Namespace) -> None:
+        assert args.output == "text"
+        print("=== Inbox ===")
+        print("Message ID: msg-123")
+
+    args = Namespace(output="markdown")
+
+    _run_command(command, args)
+
+    assert capsys.readouterr().out == "# Inbox\n- **Message ID:** msg-123\n"

--- a/uv.lock
+++ b/uv.lock
@@ -1276,12 +1276,14 @@ version = "2.0.0"
 source = { editable = "src/mail/daemon" }
 dependencies = [
     { name = "httpx" },
+    { name = "mail-protocol" },
     { name = "pydantic" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "mail-protocol", editable = "src/mail/protocol" },
     { name = "pydantic", specifier = ">=2.11.7" },
 ]
 


### PR DESCRIPTION
- Added custom formatter for printing help message to make them more readable for human and agent users
- Added `markdown` option for `mail` CLI output