### PR TITLE
Box query params + slash-free box/swarm endpoints

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -56,12 +56,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AuthPasswordResetResponse'
-  /swarms/:
+  /swarms:
     get:
       tags:
       - swarms
       summary: Get basic server information and metadata
-      operationId: get_swarms_swarms__get
+      operationId: get_swarms_swarms_get
       responses:
         '200':
           description: Successful Response
@@ -95,12 +95,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SwarmHealthGetResponse'
-  /inbox/:
+  /inbox:
     get:
       tags:
       - inbox
       summary: Get a list of inbox messages
-      operationId: get_inbox_inbox__get
+      operationId: get_inbox_inbox_get
       responses:
         '200':
           description: Successful Response
@@ -133,12 +133,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/InboxMessageDeleteResponse'
-  /outbox/:
+  /outbox:
     get:
       tags:
       - outbox
       summary: Get a list of outbox messages
-      operationId: get_outbox_outbox__get
+      operationId: get_outbox_outbox_get
       responses:
         '200':
           description: Successful Response
@@ -159,12 +159,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OutboxMessageGetResponse'
-  /drafts/:
+  /drafts:
     get:
       tags:
       - drafts
       summary: Get a list of message drafts
-      operationId: get_drafts_drafts__get
+      operationId: get_drafts_drafts_get
       responses:
         '200':
           description: Successful Response
@@ -176,7 +176,7 @@ paths:
       tags:
       - drafts
       summary: Create a new message draft
-      operationId: post_draft_drafts__post
+      operationId: post_draft_drafts_post
       responses:
         '200':
           description: Successful Response
@@ -222,12 +222,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DraftSendPostResponse'
-  /trash/:
+  /trash:
     get:
       tags:
       - trash
       summary: Get a list of messages in trash
-      operationId: get_trashed_messages_trash__get
+      operationId: get_trashed_messages_trash_get
       responses:
         '200':
           description: Successful Response

--- a/src/mail/client/src/mail_client/cli.py
+++ b/src/mail/client/src/mail_client/cli.py
@@ -109,6 +109,37 @@ EXAMPLES = [
 ]
 
 
+def _add_box_filter_args(box_parser: argparse.ArgumentParser) -> None:
+    """
+    Register the shared query-param flags for the "GET box" commands
+    (inbox, outbox, drafts, trash). Defaults are left as ``None`` so unset
+    flags are simply not sent and the server applies its own defaults.
+    """
+
+    box_parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="max number of entries to return (1-100)",
+    )
+    box_parser.add_argument(
+        "--offset", type=int, default=None, help="number of entries to skip"
+    )
+    box_parser.add_argument(
+        "--sort-by",
+        dest="sort_by",
+        choices=["sent_at", "entered_at"],
+        default=None,
+        help="timestamp field to sort by",
+    )
+    box_parser.add_argument(
+        "--order",
+        choices=["asc", "desc"],
+        default=None,
+        help="sort direction",
+    )
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = make_arg_parser(
         prog="mail",
@@ -194,6 +225,7 @@ def build_parser() -> argparse.ArgumentParser:
     inbox_p = subparsers.add_parser(
         "inbox", aliases=["i"], prog="mail inbox", help=inbox_d, description=inbox_d
     )
+    _add_box_filter_args(inbox_p)
     inbox_p.set_defaults(func=cmd_inbox, cmd="inbox")
 
     # command `inbox-open`
@@ -213,6 +245,7 @@ def build_parser() -> argparse.ArgumentParser:
     outbox_p = subparsers.add_parser(
         "outbox", aliases=["O"], prog="mail outbox", help=outbox_d, description=outbox_d
     )
+    _add_box_filter_args(outbox_p)
     outbox_p.set_defaults(func=cmd_outbox, cmd="outbox")
 
     # command `outbox-open`
@@ -236,6 +269,7 @@ def build_parser() -> argparse.ArgumentParser:
         help=drafts_d,
         description=drafts_d,
     )
+    _add_box_filter_args(drafts_p)
     drafts_p.set_defaults(func=cmd_drafts, cmd="drafts")
 
     # command `drafts-open`
@@ -255,6 +289,7 @@ def build_parser() -> argparse.ArgumentParser:
     trash_p = subparsers.add_parser(
         "trash", aliases=["t"], prog="mail trash", help=trash_d, description=trash_d
     )
+    _add_box_filter_args(trash_p)
     trash_p.set_defaults(func=cmd_trash, cmd="trash")
 
     # command `trash-open`

--- a/src/mail/client/src/mail_client/commands/_box_filters.py
+++ b/src/mail/client/src/mail_client/commands/_box_filters.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Addison Kline
+
+from argparse import Namespace
+
+
+def box_filter_params(args: Namespace) -> dict[str, str | int]:
+    """
+    Collect the shared "GET box" query-param flags (``--limit``, ``--offset``,
+    ``--sort-by``, ``--order``) from parsed CLI args, omitting any left unset
+    so the server applies its own defaults.
+    """
+
+    params: dict[str, str | int] = {}
+    for flag in ("limit", "offset", "sort_by", "order"):
+        value = getattr(args, flag, None)
+        if value is not None:
+            params[flag] = value
+    return params

--- a/src/mail/client/src/mail_client/commands/compose.py
+++ b/src/mail/client/src/mail_client/commands/compose.py
@@ -29,7 +29,7 @@ def cmd_compose(args: Namespace) -> None:
         body=args.body,
     )
     response = httpx.post(
-        url=f"{MAIL_SERVER}/drafts/",
+        url=f"{MAIL_SERVER}/drafts",
         headers={
             "Authorization": f"Bearer {MAIL_TOKEN}",
             "User-Agent": "Multi-Agent-Interface-Layer-CLI-Client/2.0.0 (github.com/charonlabs/mail)",

--- a/src/mail/client/src/mail_client/commands/drafts.py
+++ b/src/mail/client/src/mail_client/commands/drafts.py
@@ -8,6 +8,8 @@ import httpx
 from mail_protocol.network.responses import DraftsGetResponse
 from pydantic import ValidationError
 
+from mail_client.commands._box_filters import box_filter_params
+
 
 def cmd_drafts(args: Namespace) -> None:
     """
@@ -29,6 +31,7 @@ def cmd_drafts(args: Namespace) -> None:
             "Authorization": f"Bearer {MAIL_TOKEN}",
             "User-Agent": "Multi-Agent-Interface-Layer-CLI-Client/2.0.0 (github.com/charonlabs/mail)",
         },
+        params=box_filter_params(args),
     )
 
     # 3. parse and validate server response

--- a/src/mail/client/src/mail_client/commands/drafts.py
+++ b/src/mail/client/src/mail_client/commands/drafts.py
@@ -26,7 +26,7 @@ def cmd_drafts(args: Namespace) -> None:
 
     # 2. hit the server endpoint `GET /drafts`
     response = httpx.get(
-        url=f"{MAIL_SERVER}/drafts/",
+        url=f"{MAIL_SERVER}/drafts",
         headers={
             "Authorization": f"Bearer {MAIL_TOKEN}",
             "User-Agent": "Multi-Agent-Interface-Layer-CLI-Client/2.0.0 (github.com/charonlabs/mail)",

--- a/src/mail/client/src/mail_client/commands/inbox.py
+++ b/src/mail/client/src/mail_client/commands/inbox.py
@@ -8,6 +8,8 @@ import httpx
 from mail_protocol.network.responses import InboxGetResponse
 from pydantic import ValidationError
 
+from mail_client.commands._box_filters import box_filter_params
+
 
 def cmd_inbox(args: Namespace) -> None:
     """
@@ -29,6 +31,7 @@ def cmd_inbox(args: Namespace) -> None:
             "Authorization": f"Bearer {MAIL_TOKEN}",
             "User-Agent": "Multi-Agent-Interface-Layer-CLI-Client/2.0.0 (github.com/charonlabs/mail)",
         },
+        params=box_filter_params(args),
     )
 
     # 3. parse and validate server response

--- a/src/mail/client/src/mail_client/commands/inbox.py
+++ b/src/mail/client/src/mail_client/commands/inbox.py
@@ -26,7 +26,7 @@ def cmd_inbox(args: Namespace) -> None:
 
     # 2. hit the server endpoint `GET /inbox`
     response = httpx.get(
-        url=f"{MAIL_SERVER}/inbox/",
+        url=f"{MAIL_SERVER}/inbox",
         headers={
             "Authorization": f"Bearer {MAIL_TOKEN}",
             "User-Agent": "Multi-Agent-Interface-Layer-CLI-Client/2.0.0 (github.com/charonlabs/mail)",

--- a/src/mail/client/src/mail_client/commands/outbox.py
+++ b/src/mail/client/src/mail_client/commands/outbox.py
@@ -8,6 +8,8 @@ import httpx
 from mail_protocol.network.responses import OutboxGetResponse
 from pydantic import ValidationError
 
+from mail_client.commands._box_filters import box_filter_params
+
 
 def cmd_outbox(args: Namespace) -> None:
     """
@@ -29,6 +31,7 @@ def cmd_outbox(args: Namespace) -> None:
             "Authorization": f"Bearer {MAIL_TOKEN}",
             "User-Agent": "Multi-Agent-Interface-Layer-CLI-Client/2.0.0 (github.com/charonlabs/mail)",
         },
+        params=box_filter_params(args),
     )
 
     # 3. parse and validate server response

--- a/src/mail/client/src/mail_client/commands/outbox.py
+++ b/src/mail/client/src/mail_client/commands/outbox.py
@@ -26,7 +26,7 @@ def cmd_outbox(args: Namespace) -> None:
 
     # 2. hit the server endpoint `GET /outbox`
     response = httpx.get(
-        url=f"{MAIL_SERVER}/outbox/",
+        url=f"{MAIL_SERVER}/outbox",
         headers={
             "Authorization": f"Bearer {MAIL_TOKEN}",
             "User-Agent": "Multi-Agent-Interface-Layer-CLI-Client/2.0.0 (github.com/charonlabs/mail)",

--- a/src/mail/client/src/mail_client/commands/swarm_list.py
+++ b/src/mail/client/src/mail_client/commands/swarm_list.py
@@ -26,7 +26,7 @@ def cmd_swarm_list(args: Namespace) -> None:
 
     # 2. Attempt to get the list of swarms on the MAIL server
     response = httpx.get(
-        url=f"{MAIL_SERVER}/swarms/",
+        url=f"{MAIL_SERVER}/swarms",
         headers={
             "User-Agent": "Multi-Agent-Interface-Layer-CLI-Client/2.0.0 (github.com/charonlabs/mail)",
             "Authorization": f"Bearer {MAIL_TOKEN}",

--- a/src/mail/client/src/mail_client/commands/trash.py
+++ b/src/mail/client/src/mail_client/commands/trash.py
@@ -26,7 +26,7 @@ def cmd_trash(args: Namespace) -> None:
 
     # 2. hit the server endpoint `GET /trash`
     response = httpx.get(
-        url=f"{MAIL_SERVER}/trash/",
+        url=f"{MAIL_SERVER}/trash",
         headers={
             "Authorization": f"Bearer {MAIL_TOKEN}",
             "User-Agent": "Multi-Agent-Interface-Layer-CLI-Client/2.0.0 (github.com/charonlabs/mail)",

--- a/src/mail/client/src/mail_client/commands/trash.py
+++ b/src/mail/client/src/mail_client/commands/trash.py
@@ -8,6 +8,8 @@ import httpx
 from mail_protocol.network.responses import TrashGetResponse
 from pydantic import ValidationError
 
+from mail_client.commands._box_filters import box_filter_params
+
 
 def cmd_trash(args: Namespace) -> None:
     """
@@ -29,6 +31,7 @@ def cmd_trash(args: Namespace) -> None:
             "Authorization": f"Bearer {MAIL_TOKEN}",
             "User-Agent": "Multi-Agent-Interface-Layer-CLI-Client/2.0.0 (github.com/charonlabs/mail)",
         },
+        params=box_filter_params(args),
     )
 
     # 3. parse and validate server response

--- a/src/mail/protocol/src/mail_protocol/network/requests.py
+++ b/src/mail/protocol/src/mail_protocol/network/requests.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2025-26 Addison Kline
 
-from typing import Annotated
+from typing import Annotated, Literal
 
-from pydantic import AfterValidator, BaseModel
+from pydantic import AfterValidator, BaseModel, Field
 
 from mail_protocol.core.lists import MAILListPolicy
 from mail_protocol.core.messages import MAILMessage
@@ -205,3 +205,23 @@ class ListMemberPostRequest(BaseModel):
     """
 
     member_address: Annotated[str, AfterValidator(validate_mail_address)]
+
+
+#
+# Query parameters
+#
+class BoxFilterParams(BaseModel):
+    """
+    Query parameters for "GET box" endpoints (i.e. inbox, outbox, trash).
+    """
+
+    model_config = {"extra": "forbid"}
+
+    limit: int = Field(20, gt=0, le=100)
+    offset: int = Field(0, ge=0)
+    # sent_at: timestamp when the MAIL message was sent
+    # entered_at: timestamp when the message entered the user's box
+    sort_by: Literal["sent_at", "entered_at"] = "entered_at"
+    # asc: ascending
+    # desc: descending
+    order: Literal["asc", "desc"] = "desc"

--- a/src/mail/server/src/mail_server/backends/base.py
+++ b/src/mail/server/src/mail_server/backends/base.py
@@ -38,6 +38,7 @@ from mail_protocol.network.requests import (
     AdminWebhooksPatchRequest,
     AdminWebhooksPostRequest,
     AuthPasswordResetRequest,
+    BoxFilterParams,
     DaemonDeliverLocalRequest,
     DaemonDeliverRemoteRequest,
     DraftPostRequest,
@@ -137,9 +138,14 @@ class MAILServerBackend(Protocol):
     # Inbox endpoint handlers
     #
     @abstractmethod
-    async def get_inbox(self, user_agent: MAILUserAgent) -> list[MAILInboxEntrySummary]:
+    async def get_inbox(
+        self, user_agent: MAILUserAgent, filters: BoxFilterParams
+    ) -> tuple[list[MAILInboxEntrySummary], int]:
         """
-        Get the user-agent's inbox.
+        Get a sorted, paginated page of the user-agent's inbox.
+
+        Returns ``(page, total)`` where ``total`` is the box size before
+        pagination, so callers can populate pagination metadata.
         """
 
         pass
@@ -169,10 +175,13 @@ class MAILServerBackend(Protocol):
     #
     @abstractmethod
     async def get_outbox(
-        self, user_agent: MAILUserAgent
-    ) -> list[MAILOutboxEntrySummary]:
+        self, user_agent: MAILUserAgent, filters: BoxFilterParams
+    ) -> tuple[list[MAILOutboxEntrySummary], int]:
         """
-        Get the user-agent's outbox.
+        Get a sorted, paginated page of the user-agent's outbox.
+
+        Returns ``(page, total)`` where ``total`` is the box size before
+        pagination, so callers can populate pagination metadata.
         """
 
         pass
@@ -192,10 +201,13 @@ class MAILServerBackend(Protocol):
     #
     @abstractmethod
     async def get_drafts(
-        self, user_agent: MAILUserAgent
-    ) -> list[MAILDraftsEntrySummary]:
+        self, user_agent: MAILUserAgent, filters: BoxFilterParams
+    ) -> tuple[list[MAILDraftsEntrySummary], int]:
         """
-        Get the user-agent's draft box.
+        Get a sorted, paginated page of the user-agent's draft box.
+
+        Returns ``(page, total)`` where ``total`` is the box size before
+        pagination, so callers can populate pagination metadata.
         """
 
         pass
@@ -249,9 +261,14 @@ class MAILServerBackend(Protocol):
     # Trash box endpoints
     #
     @abstractmethod
-    async def get_trash(self, user_agent: MAILUserAgent) -> list[MAILTrashEntrySummary]:
+    async def get_trash(
+        self, user_agent: MAILUserAgent, filters: BoxFilterParams
+    ) -> tuple[list[MAILTrashEntrySummary], int]:
         """
-        Get a list of messages in the user-agent's trash box.
+        Get a sorted, paginated page of the user-agent's trash box.
+
+        Returns ``(page, total)`` where ``total`` is the box size before
+        pagination, so callers can populate pagination metadata.
         """
 
         pass

--- a/src/mail/server/src/mail_server/backends/memory/api.py
+++ b/src/mail/server/src/mail_server/backends/memory/api.py
@@ -4,6 +4,7 @@
 import asyncio
 import logging
 import uuid
+from collections.abc import Callable
 from copy import deepcopy
 from datetime import UTC, datetime
 from typing import Any
@@ -35,6 +36,7 @@ from mail_protocol.network.requests import (
     AdminWebhooksPatchRequest,
     AdminWebhooksPostRequest,
     AuthPasswordResetRequest,
+    BoxFilterParams,
     DaemonDeliverLocalRequest,
     DaemonDeliverRemoteRequest,
     DraftPostRequest,
@@ -91,6 +93,22 @@ def _is_agent_recipient(address: str) -> bool:
     if address.startswith(f"{LIST_ADDRESS_PREFIX}:"):
         return False
     return address.count("@") == 2
+
+
+def _paginate_box(
+    entries: list[Any], filters: BoxFilterParams, key: Callable[[Any], Any]
+) -> tuple[list[Any], int]:
+    """
+    Sort ``entries`` by ``key`` (honoring ``filters.order``) and return one
+    page per ``filters.limit`` / ``filters.offset``.
+
+    Returns ``(page, total)`` where ``total`` is the count before slicing.
+    """
+
+    total = len(entries)
+    ordered = sorted(entries, key=key, reverse=filters.order == "desc")
+    page = ordered[filters.offset : filters.offset + filters.limit]
+    return page, total
 
 
 class MemoryBackend(MAILServerBackend):
@@ -316,11 +334,34 @@ class MemoryBackend(MAILServerBackend):
         return "ok"
 
     #
+    # Box query helpers
+    #
+    def _box_sort_key(
+        self, filters: BoxFilterParams, entered_field: str
+    ) -> Callable[[Any], Any]:
+        """
+        Build the sort key for a "GET box" page.
+
+        ``entered_at`` sorts by ``entered_field`` — the timestamp at which the
+        entry landed in this box. ``sent_at`` sorts by the underlying
+        ``MAILMessage.sent_at`` (resolved via ``self.messages``), which is the
+        original send time and is distinct from arrival for inbox/trash. Only
+        valid for boxes whose entries reference a real message — drafts reject
+        ``sent_at`` at the router, since a draft has no send time.
+        """
+
+        if filters.sort_by == "sent_at":
+            return lambda entry: self.messages[entry.message_id].sent_at
+        return lambda entry: getattr(entry, entered_field)
+
+    #
     # Inbox endpoint handlers
     #
-    async def get_inbox(self, user_agent: MAILUserAgent) -> list[MAILInboxEntrySummary]:
+    async def get_inbox(
+        self, user_agent: MAILUserAgent, filters: BoxFilterParams
+    ) -> tuple[list[MAILInboxEntrySummary], int]:
         """
-        Get the user-agent's inbox.
+        Get a sorted, paginated page of the user-agent's inbox.
         """
 
         ua_address = user_agent.get_address()
@@ -335,7 +376,9 @@ class MemoryBackend(MAILServerBackend):
                 raise ValueError(f"no inbox entry found for message ID {msg_id}")
             inbox_entries.append(inbox_entry)
 
-        return inbox_entries
+        return _paginate_box(
+            inbox_entries, filters, self._box_sort_key(filters, "received_at")
+        )
 
     async def get_inbox_message(
         self, user_agent: MAILUserAgent, message_id: str
@@ -379,10 +422,10 @@ class MemoryBackend(MAILServerBackend):
     # Outbox endpoint handlers
     #
     async def get_outbox(
-        self, user_agent: MAILUserAgent
-    ) -> list[MAILOutboxEntrySummary]:
+        self, user_agent: MAILUserAgent, filters: BoxFilterParams
+    ) -> tuple[list[MAILOutboxEntrySummary], int]:
         """
-        Get the user-agent's outbox.
+        Get a sorted, paginated page of the user-agent's outbox.
         """
 
         ua_address = user_agent.get_address()
@@ -397,7 +440,9 @@ class MemoryBackend(MAILServerBackend):
                 raise ValueError(f"no outbox entry found for message ID {msg_id}")
             outbox_entries.append(outbox_entry)
 
-        return outbox_entries
+        return _paginate_box(
+            outbox_entries, filters, self._box_sort_key(filters, "sent_at")
+        )
 
     async def get_outbox_message(
         self, user_agent: MAILUserAgent, message_id: str
@@ -433,10 +478,10 @@ class MemoryBackend(MAILServerBackend):
     # Drafts box endpoints
     #
     async def get_drafts(
-        self, user_agent: MAILUserAgent
-    ) -> list[MAILDraftsEntrySummary]:
+        self, user_agent: MAILUserAgent, filters: BoxFilterParams
+    ) -> tuple[list[MAILDraftsEntrySummary], int]:
         """
-        Get the user-agent's draft box.
+        Get a sorted, paginated page of the user-agent's draft box.
         """
 
         ua_address = user_agent.get_address()
@@ -451,7 +496,9 @@ class MemoryBackend(MAILServerBackend):
                 raise ValueError(f"draft with ID {draft_id} not found in draft entries")
             draft_entries.append(draft_entry.summarize())
 
-        return draft_entries
+        # Drafts have no send time, so `sort_by=sent_at` is rejected at the
+        # router; only `entered_at` (created_at) reaches here.
+        return _paginate_box(draft_entries, filters, lambda entry: entry.created_at)
 
     async def post_draft(
         self,
@@ -571,9 +618,11 @@ class MemoryBackend(MAILServerBackend):
     #
     # Trash box endpoints
     #
-    async def get_trash(self, user_agent: MAILUserAgent) -> list[MAILTrashEntrySummary]:
+    async def get_trash(
+        self, user_agent: MAILUserAgent, filters: BoxFilterParams
+    ) -> tuple[list[MAILTrashEntrySummary], int]:
         """
-        Get a list of messages in the user-agent's trash box.
+        Get a sorted, paginated page of the user-agent's trash box.
         """
 
         ua_address = user_agent.get_address()
@@ -588,7 +637,9 @@ class MemoryBackend(MAILServerBackend):
                 raise ValueError(f"message with ID {msg_id} not found in trash entries")
             trash_entries.append(trash_entry.summarize())
 
-        return trash_entries
+        return _paginate_box(
+            trash_entries, filters, self._box_sort_key(filters, "trashed_at")
+        )
 
     async def get_trash_message(
         self, user_agent: MAILUserAgent, message_id: str
@@ -1234,8 +1285,7 @@ class MemoryBackend(MAILServerBackend):
         # without firing webhooks.
         if user_agent.user_agent.ua_type != "agent":
             logger.debug(
-                f"skipping `mail.delivered` webhooks for non-agent "
-                f"recipient {address}"
+                f"skipping `mail.delivered` webhooks for non-agent recipient {address}"
             )
             return
 

--- a/src/mail/server/src/mail_server/routers/drafts.py
+++ b/src/mail/server/src/mail_server/routers/drafts.py
@@ -11,7 +11,9 @@ from mail_protocol.network.responses import (
 )
 
 from mail_server.auth import validate_user_agent
+from mail_server.utils import build_box_metadata
 from mail_server.validators import (
+    validate_box_filter_params,
     validate_post_draft_request,
     validate_post_draft_send_request,
 )
@@ -25,14 +27,23 @@ router = APIRouter(prefix="/drafts", tags=["drafts"])
 async def get_drafts(request: Request) -> DraftsGetResponse:
     backend = request.app.state.backend
     user_agent = await validate_user_agent(backend=backend, request=request)
+    filters = await validate_box_filter_params(request)
+    if filters.sort_by == "sent_at":
+        raise HTTPException(
+            status_code=422,
+            detail="sort_by=sent_at is not supported for drafts (drafts have no send time)",
+        )
     try:
-        result = await backend.get_drafts(user_agent=user_agent)
+        entries, total = await backend.get_drafts(user_agent, filters)
     except ValueError:
         raise HTTPException(
             status_code=404, detail=f"draft box not found for address {user_agent}"
         )
 
-    return DraftsGetResponse(entries=result, metadata={})
+    return DraftsGetResponse(
+        entries=entries,
+        metadata=build_box_metadata(filters, total, len(entries)),
+    )
 
 
 @router.post(

--- a/src/mail/server/src/mail_server/routers/drafts.py
+++ b/src/mail/server/src/mail_server/routers/drafts.py
@@ -22,7 +22,7 @@ router = APIRouter(prefix="/drafts", tags=["drafts"])
 
 
 @router.get(
-    "/", summary="Get a list of message drafts", response_model=DraftsGetResponse
+    "", summary="Get a list of message drafts", response_model=DraftsGetResponse
 )
 async def get_drafts(request: Request) -> DraftsGetResponse:
     backend = request.app.state.backend
@@ -46,9 +46,7 @@ async def get_drafts(request: Request) -> DraftsGetResponse:
     )
 
 
-@router.post(
-    "/", summary="Create a new message draft", response_model=DraftPostResponse
-)
+@router.post("", summary="Create a new message draft", response_model=DraftPostResponse)
 async def post_draft(request: Request) -> DraftPostResponse:
     backend = request.app.state.backend
     user_agent = await validate_user_agent(backend=backend, request=request)

--- a/src/mail/server/src/mail_server/routers/inbox.py
+++ b/src/mail/server/src/mail_server/routers/inbox.py
@@ -9,6 +9,8 @@ from mail_protocol.network.responses import (
 )
 
 from mail_server.auth import validate_user_agent
+from mail_server.utils import build_box_metadata
+from mail_server.validators import validate_box_filter_params
 
 router = APIRouter(prefix="/inbox", tags=["inbox"])
 
@@ -21,8 +23,9 @@ router = APIRouter(prefix="/inbox", tags=["inbox"])
 async def get_inbox(request: Request) -> InboxGetResponse:
     backend = request.app.state.backend
     user_agent = await validate_user_agent(backend=backend, request=request)
+    filters = await validate_box_filter_params(request)
     try:
-        result = await backend.get_inbox(user_agent)
+        entries, total = await backend.get_inbox(user_agent, filters)
     except ValueError:
         raise HTTPException(
             status_code=404,
@@ -30,8 +33,8 @@ async def get_inbox(request: Request) -> InboxGetResponse:
         )
 
     return InboxGetResponse(
-        entries=result,
-        metadata={},
+        entries=entries,
+        metadata=build_box_metadata(filters, total, len(entries)),
     )
 
 

--- a/src/mail/server/src/mail_server/routers/inbox.py
+++ b/src/mail/server/src/mail_server/routers/inbox.py
@@ -16,7 +16,7 @@ router = APIRouter(prefix="/inbox", tags=["inbox"])
 
 
 @router.get(
-    "/",
+    "",
     summary="Get a list of inbox messages",
     response_model=InboxGetResponse,
 )

--- a/src/mail/server/src/mail_server/routers/outbox.py
+++ b/src/mail/server/src/mail_server/routers/outbox.py
@@ -5,6 +5,8 @@ from fastapi import APIRouter, HTTPException, Request
 from mail_protocol.network.responses import OutboxGetResponse, OutboxMessageGetResponse
 
 from mail_server.auth import validate_user_agent
+from mail_server.utils import build_box_metadata
+from mail_server.validators import validate_box_filter_params
 
 router = APIRouter(prefix="/outbox", tags=["outbox"])
 
@@ -15,8 +17,9 @@ router = APIRouter(prefix="/outbox", tags=["outbox"])
 async def get_outbox(request: Request) -> OutboxGetResponse:
     backend = request.app.state.backend
     user_agent = await validate_user_agent(backend=backend, request=request)
+    filters = await validate_box_filter_params(request)
     try:
-        result = await backend.get_outbox(user_agent=user_agent)
+        entries, total = await backend.get_outbox(user_agent, filters)
     except ValueError:
         raise HTTPException(
             status_code=404,
@@ -24,8 +27,8 @@ async def get_outbox(request: Request) -> OutboxGetResponse:
         )
 
     return OutboxGetResponse(
-        entries=result,
-        metadata={},
+        entries=entries,
+        metadata=build_box_metadata(filters, total, len(entries)),
     )
 
 

--- a/src/mail/server/src/mail_server/routers/outbox.py
+++ b/src/mail/server/src/mail_server/routers/outbox.py
@@ -12,7 +12,7 @@ router = APIRouter(prefix="/outbox", tags=["outbox"])
 
 
 @router.get(
-    "/", summary="Get a list of outbox messages", response_model=OutboxGetResponse
+    "", summary="Get a list of outbox messages", response_model=OutboxGetResponse
 )
 async def get_outbox(request: Request) -> OutboxGetResponse:
     backend = request.app.state.backend

--- a/src/mail/server/src/mail_server/routers/swarms.py
+++ b/src/mail/server/src/mail_server/routers/swarms.py
@@ -14,7 +14,7 @@ router = APIRouter(prefix="/swarms", tags=["swarms"])
 
 
 @router.get(
-    "/",
+    "",
     summary="Get basic server information and metadata",
     response_model=SwarmsGetResponse,
 )

--- a/src/mail/server/src/mail_server/routers/trash.py
+++ b/src/mail/server/src/mail_server/routers/trash.py
@@ -17,7 +17,7 @@ router = APIRouter(prefix="/trash", tags=["trash"])
 
 
 @router.get(
-    "/", summary="Get a list of messages in trash", response_model=TrashGetResponse
+    "", summary="Get a list of messages in trash", response_model=TrashGetResponse
 )
 async def get_trashed_messages(request: Request) -> TrashGetResponse:
     backend = request.app.state.backend

--- a/src/mail/server/src/mail_server/routers/trash.py
+++ b/src/mail/server/src/mail_server/routers/trash.py
@@ -10,6 +10,8 @@ from mail_protocol.network.responses import (
 )
 
 from mail_server.auth import validate_user_agent
+from mail_server.utils import build_box_metadata
+from mail_server.validators import validate_box_filter_params
 
 router = APIRouter(prefix="/trash", tags=["trash"])
 
@@ -20,8 +22,9 @@ router = APIRouter(prefix="/trash", tags=["trash"])
 async def get_trashed_messages(request: Request) -> TrashGetResponse:
     backend = request.app.state.backend
     user_agent = await validate_user_agent(backend=backend, request=request)
+    filters = await validate_box_filter_params(request)
     try:
-        result = await backend.get_trash(user_agent=user_agent)
+        entries, total = await backend.get_trash(user_agent, filters)
     except ValueError:
         raise HTTPException(
             status_code=404,
@@ -29,8 +32,8 @@ async def get_trashed_messages(request: Request) -> TrashGetResponse:
         )
 
     return TrashGetResponse(
-        entries=result,
-        metadata={},
+        entries=entries,
+        metadata=build_box_metadata(filters, total, len(entries)),
     )
 
 

--- a/src/mail/server/src/mail_server/utils.py
+++ b/src/mail/server/src/mail_server/utils.py
@@ -2,6 +2,27 @@
 # Copyright (c) 2026 Addison Kline
 
 from importlib import metadata
+from typing import Any
+
+from mail_protocol.network.requests import BoxFilterParams
+
+
+def build_box_metadata(
+    filters: BoxFilterParams, total: int, returned: int
+) -> dict[str, Any]:
+    """
+    Build the `metadata` block returned by the "GET box" endpoints, echoing
+    the applied filters alongside the pagination counts so clients can page.
+    """
+
+    return {
+        "total": total,
+        "returned": returned,
+        "limit": filters.limit,
+        "offset": filters.offset,
+        "sort_by": filters.sort_by,
+        "order": filters.order,
+    }
 
 
 def get_mail_server_version() -> str:

--- a/src/mail/server/src/mail_server/validators.py
+++ b/src/mail/server/src/mail_server/validators.py
@@ -12,6 +12,7 @@ from mail_protocol.network.requests import (
     AdminWebhooksPatchRequest,
     AdminWebhooksPostRequest,
     AuthPasswordResetRequest,
+    BoxFilterParams,
     DaemonDeliverLocalRequest,
     DraftPostRequest,
     DraftSendPostRequest,
@@ -21,6 +22,27 @@ from mail_protocol.network.requests import (
 # NOTE: the except clauses below catch ValueError, which covers both
 # pydantic.ValidationError and json.JSONDecodeError — an unparseable
 # body must 422 the same way an invalid one does.
+
+
+#
+# Query parameter validators
+#
+async def validate_box_filter_params(request: Request) -> BoxFilterParams:
+    """
+    Ensure the query string is valid for the "GET box" endpoints
+    (`GET /inbox`, `GET /outbox`, `GET /trash`, `GET /drafts`).
+
+    `BoxFilterParams` declares `extra="forbid"`, so an unknown query
+    parameter 422s the same way an out-of-bounds `limit` does. Values
+    arrive as strings; pydantic coerces and bounds-checks them.
+    """
+
+    try:
+        return BoxFilterParams.model_validate(dict(request.query_params))
+    except ValueError as e:
+        raise HTTPException(
+            status_code=422, detail=f"query parameter validation failed: {e}"
+        )
 
 
 #

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -140,7 +140,7 @@ def deliver_message(app_client: TestClient, headers_for):
         daemon_headers = headers_for(DAEMON)
 
         response = app_client.post(
-            "/drafts/",
+            "/drafts",
             json={"subject": subject, "body": body},
             headers=sender_headers,
         )

--- a/tests/integration/test_admin.py
+++ b/tests/integration/test_admin.py
@@ -11,25 +11,19 @@ SWARM = "chorus"
 # ─── Agents ────────────────────────────────────────────────────────
 
 
-def test_get_agents_lists_local_addresses(
-    app_client: TestClient, headers_for
-) -> None:
+def test_get_agents_lists_local_addresses(app_client: TestClient, headers_for) -> None:
     response = app_client.get("/admin/agents", headers=headers_for(ADMIN))
     assert response.status_code == 200
     assert response.json()["agents"] == [f"sage@{SWARM}"]
 
 
 def test_get_agent_by_local_address(app_client: TestClient, headers_for) -> None:
-    response = app_client.get(
-        f"/admin/agents/sage@{SWARM}", headers=headers_for(ADMIN)
-    )
+    response = app_client.get(f"/admin/agents/sage@{SWARM}", headers=headers_for(ADMIN))
     assert response.status_code == 200
     assert response.json()["agent"]["name"] == "sage"
 
 
-def test_get_agent_unknown_returns_404(
-    app_client: TestClient, headers_for
-) -> None:
+def test_get_agent_unknown_returns_404(app_client: TestClient, headers_for) -> None:
     response = app_client.get(
         f"/admin/agents/ghost@{SWARM}", headers=headers_for(ADMIN)
     )
@@ -53,14 +47,12 @@ def test_post_agent_creates_and_can_login(
 
     # The new agent authenticates and has a working (empty) inbox.
     headers = headers_for(f"muse@{SWARM}@localhost", password="muse-password")
-    response = app_client.get("/inbox/", headers=headers)
+    response = app_client.get("/inbox", headers=headers)
     assert response.status_code == 200
     assert response.json()["entries"] == []
 
 
-def test_post_agent_duplicate_returns_409(
-    app_client: TestClient, headers_for
-) -> None:
+def test_post_agent_duplicate_returns_409(app_client: TestClient, headers_for) -> None:
     response = app_client.post(
         "/admin/agents",
         json={
@@ -110,9 +102,7 @@ def test_delete_agent_removes_account_and_boxes(
     assert response.status_code == 401
 
 
-def test_delete_agent_unknown_returns_404(
-    app_client: TestClient, headers_for
-) -> None:
+def test_delete_agent_unknown_returns_404(app_client: TestClient, headers_for) -> None:
     response = app_client.delete(
         f"/admin/agents/ghost@{SWARM}", headers=headers_for(ADMIN)
     )
@@ -122,9 +112,7 @@ def test_delete_agent_unknown_returns_404(
 # ─── Daemons ───────────────────────────────────────────────────────
 
 
-def test_get_daemons_lists_worker_names(
-    app_client: TestClient, headers_for
-) -> None:
+def test_get_daemons_lists_worker_names(app_client: TestClient, headers_for) -> None:
     response = app_client.get("/admin/daemons", headers=headers_for(ADMIN))
     assert response.status_code == 200
     assert response.json()["daemons"] == ["dummy"]
@@ -136,16 +124,12 @@ def test_get_daemon_by_worker_name(app_client: TestClient, headers_for) -> None:
     assert response.json()["daemon"]["worker_name"] == "dummy"
 
 
-def test_get_daemon_unknown_returns_404(
-    app_client: TestClient, headers_for
-) -> None:
+def test_get_daemon_unknown_returns_404(app_client: TestClient, headers_for) -> None:
     response = app_client.get("/admin/daemons/ghost", headers=headers_for(ADMIN))
     assert response.status_code == 404
 
 
-def test_post_daemon_creates_and_can_login(
-    app_client: TestClient, headers_for
-) -> None:
+def test_post_daemon_creates_and_can_login(app_client: TestClient, headers_for) -> None:
     response = app_client.post(
         "/admin/daemons",
         json={"worker_name": "worker2", "daemon_password": "worker2-password"},
@@ -158,9 +142,7 @@ def test_post_daemon_creates_and_can_login(
     assert response.status_code == 200
 
 
-def test_post_daemon_duplicate_returns_409(
-    app_client: TestClient, headers_for
-) -> None:
+def test_post_daemon_duplicate_returns_409(app_client: TestClient, headers_for) -> None:
     response = app_client.post(
         "/admin/daemons",
         json={"worker_name": "dummy", "daemon_password": "irrelevant"},
@@ -172,19 +154,13 @@ def test_post_daemon_duplicate_returns_409(
 def test_delete_daemon_removes_account(
     app_client: TestClient, headers_for, backend: MemoryBackend
 ) -> None:
-    response = app_client.delete(
-        "/admin/daemons/dummy", headers=headers_for(ADMIN)
-    )
+    response = app_client.delete("/admin/daemons/dummy", headers=headers_for(ADMIN))
     assert response.status_code == 200
     assert "daemon:dummy@localhost" not in backend.user_agents
 
 
-def test_delete_daemon_unknown_returns_404(
-    app_client: TestClient, headers_for
-) -> None:
-    response = app_client.delete(
-        "/admin/daemons/ghost", headers=headers_for(ADMIN)
-    )
+def test_delete_daemon_unknown_returns_404(app_client: TestClient, headers_for) -> None:
+    response = app_client.delete("/admin/daemons/ghost", headers=headers_for(ADMIN))
     assert response.status_code == 404
 
 
@@ -203,16 +179,12 @@ def test_get_user_by_id(app_client: TestClient, headers_for) -> None:
     assert response.json()["user"]["user_id"] == "alice"
 
 
-def test_get_user_unknown_returns_404(
-    app_client: TestClient, headers_for
-) -> None:
+def test_get_user_unknown_returns_404(app_client: TestClient, headers_for) -> None:
     response = app_client.get("/admin/users/ghost", headers=headers_for(ADMIN))
     assert response.status_code == 404
 
 
-def test_post_user_creates_and_can_login(
-    app_client: TestClient, headers_for
-) -> None:
+def test_post_user_creates_and_can_login(app_client: TestClient, headers_for) -> None:
     response = app_client.post(
         "/admin/users",
         json={"user_id": "carol", "user_password": "carol-password"},
@@ -222,13 +194,11 @@ def test_post_user_creates_and_can_login(
     assert response.json()["user"]["user_id"] == "carol"
 
     headers = headers_for("user:carol@localhost", password="carol-password")
-    response = app_client.get("/inbox/", headers=headers)
+    response = app_client.get("/inbox", headers=headers)
     assert response.status_code == 200
 
 
-def test_post_user_duplicate_returns_409(
-    app_client: TestClient, headers_for
-) -> None:
+def test_post_user_duplicate_returns_409(app_client: TestClient, headers_for) -> None:
     response = app_client.post(
         "/admin/users",
         json={"user_id": "alice", "user_password": "irrelevant"},
@@ -246,12 +216,8 @@ def test_delete_user_removes_account_and_boxes(
     assert "user:bob@localhost" not in backend.inboxes
 
 
-def test_delete_user_unknown_returns_404(
-    app_client: TestClient, headers_for
-) -> None:
-    response = app_client.delete(
-        "/admin/users/ghost", headers=headers_for(ADMIN)
-    )
+def test_delete_user_unknown_returns_404(app_client: TestClient, headers_for) -> None:
+    response = app_client.delete("/admin/users/ghost", headers=headers_for(ADMIN))
     assert response.status_code == 404
 
 
@@ -271,9 +237,7 @@ def test_post_swarm_creates(app_client: TestClient, headers_for) -> None:
     assert response.status_code == 200
 
 
-def test_post_swarm_duplicate_returns_409(
-    app_client: TestClient, headers_for
-) -> None:
+def test_post_swarm_duplicate_returns_409(app_client: TestClient, headers_for) -> None:
     response = app_client.post(
         "/admin/swarms",
         json={"name": SWARM, "description": "dupe", "keywords": []},
@@ -283,18 +247,14 @@ def test_post_swarm_duplicate_returns_409(
 
 
 def test_delete_swarm_removes(app_client: TestClient, headers_for) -> None:
-    response = app_client.delete(
-        f"/admin/swarms/{SWARM}", headers=headers_for(ADMIN)
-    )
+    response = app_client.delete(f"/admin/swarms/{SWARM}", headers=headers_for(ADMIN))
     assert response.status_code == 200
 
     response = app_client.get(f"/swarms/{SWARM}", headers=headers_for(ADMIN))
     assert response.status_code == 404
 
 
-def test_delete_swarm_unknown_returns_404(
-    app_client: TestClient, headers_for
-) -> None:
+def test_delete_swarm_unknown_returns_404(app_client: TestClient, headers_for) -> None:
     response = app_client.delete(
         "/admin/swarms/nonexistent", headers=headers_for(ADMIN)
     )

--- a/tests/integration/test_authz.py
+++ b/tests/integration/test_authz.py
@@ -17,7 +17,11 @@ DAEMON = "daemon:dummy@localhost"
 
 ADMIN_ONLY_REQUESTS = [
     ("GET", "/admin/agents", None),
-    ("POST", "/admin/agents", {"agent_name": "x", "swarm_name": "chorus", "agent_password": "pw"}),
+    (
+        "POST",
+        "/admin/agents",
+        {"agent_name": "x", "swarm_name": "chorus", "agent_password": "pw"},
+    ),
     ("GET", "/admin/daemons", None),
     ("GET", "/admin/users", None),
     ("POST", "/admin/swarms", {"name": "x", "description": "d", "keywords": []}),
@@ -86,9 +90,7 @@ def test_daemon_endpoints_accept_daemon(app_client: TestClient, headers_for) -> 
     assert response.status_code == 200
 
 
-@pytest.mark.parametrize(
-    "path", ["/inbox/", "/outbox/", "/drafts/", "/trash/", "/lists"]
-)
+@pytest.mark.parametrize("path", ["/inbox", "/outbox", "/drafts", "/trash", "/lists"])
 def test_mailbox_and_list_endpoints_reject_missing_token(
     app_client: TestClient, path: str
 ) -> None:

--- a/tests/integration/test_daemon.py
+++ b/tests/integration/test_daemon.py
@@ -11,7 +11,7 @@ DAEMON = "daemon:dummy@localhost"
 
 def _compose_and_send(client: TestClient, headers: dict[str, str]) -> str:
     response = client.post(
-        "/drafts/",
+        "/drafts",
         json={"subject": "Buffered", "body": "Awaiting delivery"},
         headers=headers,
     )
@@ -31,16 +31,12 @@ def test_clear_message_buffer_returns_pending_ids_once(
     message_id = _compose_and_send(app_client, headers_for(USER))
     daemon_headers = headers_for(DAEMON)
 
-    response = app_client.post(
-        "/daemon/message-buffer/clear", headers=daemon_headers
-    )
+    response = app_client.post("/daemon/message-buffer/clear", headers=daemon_headers)
     assert response.status_code == 200
     assert response.json()["message_ids"] == [message_id]
 
     # The buffer is drained; a second clear returns nothing.
-    response = app_client.post(
-        "/daemon/message-buffer/clear", headers=daemon_headers
-    )
+    response = app_client.post("/daemon/message-buffer/clear", headers=daemon_headers)
     assert response.status_code == 200
     assert response.json()["message_ids"] == []
 
@@ -101,7 +97,7 @@ def test_deliver_local_skips_unknown_recipient(
 
     user_headers = headers_for(USER)
     response = app_client.post(
-        "/drafts/",
+        "/drafts",
         json={"subject": "Mixed", "body": "One good, one ghost"},
         headers=user_headers,
     )

--- a/tests/integration/test_flows.py
+++ b/tests/integration/test_flows.py
@@ -73,12 +73,10 @@ def test_list_fan_out_journey(
     message_id = deliver_message(USER, [LIST_ADDRESS], subject="To the list")
 
     for member in (AGENT, OTHER_USER):
-        response = app_client.get(
-            f"/inbox/{message_id}", headers=headers_for(member)
-        )
+        response = app_client.get(f"/inbox/{message_id}", headers=headers_for(member))
         assert response.status_code == 200
         assert response.json()["entry"]["message"]["subject"] == "To the list"
 
     # The sender is not a member and receives nothing.
-    response = app_client.get("/inbox/", headers=headers_for(USER))
+    response = app_client.get("/inbox", headers=headers_for(USER))
     assert response.json()["entries"] == []

--- a/tests/integration/test_mailboxes.py
+++ b/tests/integration/test_mailboxes.py
@@ -18,7 +18,7 @@ OTHER_USER = "user:bob@localhost"
 
 
 def test_inbox_starts_empty(app_client: TestClient, headers_for) -> None:
-    response = app_client.get("/inbox/", headers=headers_for(USER))
+    response = app_client.get("/inbox", headers=headers_for(USER))
     assert response.status_code == 200
     assert response.json()["entries"] == []
 
@@ -27,7 +27,7 @@ def test_inbox_lists_delivered_message(
     app_client: TestClient, headers_for, deliver_message
 ) -> None:
     message_id = deliver_message(USER, [OTHER_USER], subject="Greetings")
-    response = app_client.get("/inbox/", headers=headers_for(OTHER_USER))
+    response = app_client.get("/inbox", headers=headers_for(OTHER_USER))
     assert response.status_code == 200
     entries = response.json()["entries"]
     assert len(entries) == 1
@@ -69,7 +69,7 @@ def test_inbox_open_isolated_between_users(
 
 
 def test_outbox_starts_empty(app_client: TestClient, headers_for) -> None:
-    response = app_client.get("/outbox/", headers=headers_for(USER))
+    response = app_client.get("/outbox", headers=headers_for(USER))
     assert response.status_code == 200
     assert response.json()["entries"] == []
 
@@ -78,7 +78,7 @@ def test_outbox_entry_created_on_send_and_updated_on_delivery(
     app_client: TestClient, headers_for, deliver_message
 ) -> None:
     message_id = deliver_message(USER, [OTHER_USER])
-    response = app_client.get("/outbox/", headers=headers_for(USER))
+    response = app_client.get("/outbox", headers=headers_for(USER))
     assert response.status_code == 200
     entries = response.json()["entries"]
     assert len(entries) == 1
@@ -118,14 +118,14 @@ def test_outbox_isolated_between_users(
 
 
 def test_drafts_start_empty(app_client: TestClient, headers_for) -> None:
-    response = app_client.get("/drafts/", headers=headers_for(USER))
+    response = app_client.get("/drafts", headers=headers_for(USER))
     assert response.status_code == 200
     assert response.json()["entries"] == []
 
 
 def test_post_draft_creates_entry(app_client: TestClient, headers_for) -> None:
     response = app_client.post(
-        "/drafts/",
+        "/drafts",
         json={"subject": "A subject", "body": "A body"},
         headers=headers_for(USER),
     )
@@ -141,7 +141,7 @@ def test_post_draft_creates_entry(app_client: TestClient, headers_for) -> None:
 
 def test_post_draft_rejects_missing_field(app_client: TestClient, headers_for) -> None:
     response = app_client.post(
-        "/drafts/", json={"subject": "no body"}, headers=headers_for(USER)
+        "/drafts", json={"subject": "no body"}, headers=headers_for(USER)
     )
     assert response.status_code == 422
 
@@ -150,7 +150,7 @@ def test_post_draft_rejects_overlong_subject(
     app_client: TestClient, headers_for
 ) -> None:
     response = app_client.post(
-        "/drafts/",
+        "/drafts",
         json={"subject": "s" * (MESSAGE_SUBJECT_LEN_MAX + 1), "body": "A body"},
         headers=headers_for(USER),
     )
@@ -159,7 +159,7 @@ def test_post_draft_rejects_overlong_subject(
 
 def test_post_draft_rejects_empty_subject(app_client: TestClient, headers_for) -> None:
     response = app_client.post(
-        "/drafts/",
+        "/drafts",
         json={"subject": "", "body": "A body"},
         headers=headers_for(USER),
     )
@@ -172,7 +172,7 @@ def test_post_draft_rejects_unparseable_body(
     """An unparseable JSON body must 422 like an invalid one (not 500)."""
 
     response = app_client.post(
-        "/drafts/",
+        "/drafts",
         content=b"not json",
         headers={**headers_for(USER), "Content-Type": "application/json"},
     )
@@ -189,7 +189,7 @@ def test_get_draft_unknown_id_returns_404(app_client: TestClient, headers_for) -
 
 def test_drafts_isolated_between_users(app_client: TestClient, headers_for) -> None:
     response = app_client.post(
-        "/drafts/",
+        "/drafts",
         json={"subject": "Private", "body": "Draft"},
         headers=headers_for(USER),
     )
@@ -202,7 +202,7 @@ def test_send_draft_creates_message_and_buffers_it(
     app_client: TestClient, headers_for, backend: MemoryBackend
 ) -> None:
     response = app_client.post(
-        "/drafts/",
+        "/drafts",
         json={"subject": "Outgoing", "body": "Payload"},
         headers=headers_for(USER),
     )
@@ -228,7 +228,7 @@ def test_send_draft_rejects_empty_recipients(
     """SPEC.md §7.3: recipients MUST contain at least 1 entry."""
 
     response = app_client.post(
-        "/drafts/",
+        "/drafts",
         json={"subject": "Outgoing", "body": "Payload"},
         headers=headers_for(USER),
     )
@@ -246,7 +246,7 @@ def test_send_draft_rejects_invalid_recipients(
     app_client: TestClient, headers_for
 ) -> None:
     response = app_client.post(
-        "/drafts/",
+        "/drafts",
         json={"subject": "Outgoing", "body": "Payload"},
         headers=headers_for(USER),
     )
@@ -291,7 +291,7 @@ def _seed_trash(backend: MemoryBackend, owner: str) -> str:
 
 
 def test_trash_starts_empty(app_client: TestClient, headers_for) -> None:
-    response = app_client.get("/trash/", headers=headers_for(USER))
+    response = app_client.get("/trash", headers=headers_for(USER))
     assert response.status_code == 200
     assert response.json()["entries"] == []
 
@@ -300,7 +300,7 @@ def test_trash_lists_seeded_entry(
     app_client: TestClient, headers_for, backend: MemoryBackend
 ) -> None:
     message_id = _seed_trash(backend, USER)
-    response = app_client.get("/trash/", headers=headers_for(USER))
+    response = app_client.get("/trash", headers=headers_for(USER))
     assert response.status_code == 200
     entries = response.json()["entries"]
     assert len(entries) == 1
@@ -375,7 +375,7 @@ def test_box_metadata_reports_pagination_defaults(
 ) -> None:
     """An empty box still echoes the applied (default) filters."""
 
-    response = app_client.get("/inbox/", headers=headers_for(USER))
+    response = app_client.get("/inbox", headers=headers_for(USER))
     assert response.status_code == 200
     assert response.json()["metadata"] == {
         "total": 0,
@@ -390,7 +390,7 @@ def test_box_metadata_reports_pagination_defaults(
 def test_box_rejects_unknown_query_param(app_client: TestClient, headers_for) -> None:
     """`extra="forbid"` makes an unknown query param a 422."""
 
-    response = app_client.get("/inbox/?bogus=1", headers=headers_for(USER))
+    response = app_client.get("/inbox?bogus=1", headers=headers_for(USER))
     assert response.status_code == 422
 
 
@@ -408,7 +408,7 @@ def test_box_rejects_unknown_query_param(app_client: TestClient, headers_for) ->
 def test_box_rejects_invalid_query_params(
     app_client: TestClient, headers_for, query: str
 ) -> None:
-    response = app_client.get(f"/inbox/?{query}", headers=headers_for(USER))
+    response = app_client.get(f"/inbox?{query}", headers=headers_for(USER))
     assert response.status_code == 422
 
 
@@ -417,7 +417,7 @@ def test_box_pagination_slices_and_counts(
 ) -> None:
     ids = _seed_trash_n(backend, USER, 5)  # oldest → newest
 
-    response = app_client.get("/trash/?limit=2&offset=0", headers=headers_for(USER))
+    response = app_client.get("/trash?limit=2&offset=0", headers=headers_for(USER))
     assert response.status_code == 200
     body = response.json()
     # default sort is entered_at (trashed_at) descending → newest first
@@ -425,7 +425,7 @@ def test_box_pagination_slices_and_counts(
     assert body["metadata"]["total"] == 5
     assert body["metadata"]["returned"] == 2
 
-    response = app_client.get("/trash/?limit=2&offset=2", headers=headers_for(USER))
+    response = app_client.get("/trash?limit=2&offset=2", headers=headers_for(USER))
     assert [e["message_id"] for e in response.json()["entries"]] == [ids[2], ids[1]]
 
 
@@ -434,7 +434,7 @@ def test_box_sort_order_ascending(
 ) -> None:
     ids = _seed_trash_n(backend, USER, 3)
 
-    response = app_client.get("/trash/?order=asc", headers=headers_for(USER))
+    response = app_client.get("/trash?order=asc", headers=headers_for(USER))
     assert response.status_code == 200
     assert [e["message_id"] for e in response.json()["entries"]] == ids
 
@@ -444,7 +444,7 @@ def test_box_offset_past_end_returns_empty_page(
 ) -> None:
     _seed_trash_n(backend, USER, 3)
 
-    response = app_client.get("/trash/?offset=10", headers=headers_for(USER))
+    response = app_client.get("/trash?offset=10", headers=headers_for(USER))
     assert response.status_code == 200
     body = response.json()
     assert body["entries"] == []
@@ -462,14 +462,14 @@ def test_box_sort_by_sent_at_uses_message_send_time(
 
     ids = _seed_trash_n(backend, USER, 3)
 
-    default = app_client.get("/trash/", headers=headers_for(USER))
+    default = app_client.get("/trash", headers=headers_for(USER))
     assert [e["message_id"] for e in default.json()["entries"]] == [
         ids[2],
         ids[1],
         ids[0],
     ]
 
-    by_sent = app_client.get("/trash/?sort_by=sent_at", headers=headers_for(USER))
+    by_sent = app_client.get("/trash?sort_by=sent_at", headers=headers_for(USER))
     assert by_sent.status_code == 200
     assert [e["message_id"] for e in by_sent.json()["entries"]] == [
         ids[0],
@@ -481,10 +481,10 @@ def test_box_sort_by_sent_at_uses_message_send_time(
 def test_drafts_reject_sort_by_sent_at(app_client: TestClient, headers_for) -> None:
     """Drafts have no send time, so `sort_by=sent_at` must 422 (not silently fall back)."""
 
-    response = app_client.get("/drafts/?sort_by=sent_at", headers=headers_for(USER))
+    response = app_client.get("/drafts?sort_by=sent_at", headers=headers_for(USER))
     assert response.status_code == 422
     # other boxes still accept it
     assert (
-        app_client.get("/inbox/?sort_by=sent_at", headers=headers_for(USER)).status_code
+        app_client.get("/inbox?sort_by=sent_at", headers=headers_for(USER)).status_code
         == 200
     )

--- a/tests/integration/test_mailboxes.py
+++ b/tests/integration/test_mailboxes.py
@@ -3,6 +3,7 @@
 
 from datetime import UTC, datetime
 
+import pytest
 from fastapi.testclient import TestClient
 from mail_protocol.core.constants import MESSAGE_SUBJECT_LEN_MAX
 from mail_protocol.core.messages import MAILMessage
@@ -39,18 +40,14 @@ def test_inbox_open_returns_full_message(
     app_client: TestClient, headers_for, deliver_message
 ) -> None:
     message_id = deliver_message(USER, [OTHER_USER], body="The full body")
-    response = app_client.get(
-        f"/inbox/{message_id}", headers=headers_for(OTHER_USER)
-    )
+    response = app_client.get(f"/inbox/{message_id}", headers=headers_for(OTHER_USER))
     assert response.status_code == 200
     entry = response.json()["entry"]
     assert entry["message"]["body"] == "The full body"
     assert entry["message"]["sender"] == USER
 
 
-def test_inbox_open_unknown_id_returns_404(
-    app_client: TestClient, headers_for
-) -> None:
+def test_inbox_open_unknown_id_returns_404(app_client: TestClient, headers_for) -> None:
     response = app_client.get(
         "/inbox/11111111-1111-4111-8111-111111111111",
         headers=headers_for(USER),
@@ -94,9 +91,7 @@ def test_outbox_open_returns_full_message(
     app_client: TestClient, headers_for, deliver_message
 ) -> None:
     message_id = deliver_message(USER, [OTHER_USER], body="Sent body")
-    response = app_client.get(
-        f"/outbox/{message_id}", headers=headers_for(USER)
-    )
+    response = app_client.get(f"/outbox/{message_id}", headers=headers_for(USER))
     assert response.status_code == 200
     assert response.json()["entry"]["message"]["body"] == "Sent body"
 
@@ -115,9 +110,7 @@ def test_outbox_isolated_between_users(
     app_client: TestClient, headers_for, deliver_message
 ) -> None:
     message_id = deliver_message(USER, [OTHER_USER])
-    response = app_client.get(
-        f"/outbox/{message_id}", headers=headers_for(OTHER_USER)
-    )
+    response = app_client.get(f"/outbox/{message_id}", headers=headers_for(OTHER_USER))
     assert response.status_code == 404
 
 
@@ -142,15 +135,11 @@ def test_post_draft_creates_entry(app_client: TestClient, headers_for) -> None:
     assert draft["body"] == "A body"
     assert draft["draft_id"]
 
-    response = app_client.get(
-        f"/drafts/{draft['draft_id']}", headers=headers_for(USER)
-    )
+    response = app_client.get(f"/drafts/{draft['draft_id']}", headers=headers_for(USER))
     assert response.status_code == 200
 
 
-def test_post_draft_rejects_missing_field(
-    app_client: TestClient, headers_for
-) -> None:
+def test_post_draft_rejects_missing_field(app_client: TestClient, headers_for) -> None:
     response = app_client.post(
         "/drafts/", json={"subject": "no body"}, headers=headers_for(USER)
     )
@@ -168,9 +157,7 @@ def test_post_draft_rejects_overlong_subject(
     assert response.status_code == 422
 
 
-def test_post_draft_rejects_empty_subject(
-    app_client: TestClient, headers_for
-) -> None:
+def test_post_draft_rejects_empty_subject(app_client: TestClient, headers_for) -> None:
     response = app_client.post(
         "/drafts/",
         json={"subject": "", "body": "A body"},
@@ -192,9 +179,7 @@ def test_post_draft_rejects_unparseable_body(
     assert response.status_code == 422
 
 
-def test_get_draft_unknown_id_returns_404(
-    app_client: TestClient, headers_for
-) -> None:
+def test_get_draft_unknown_id_returns_404(app_client: TestClient, headers_for) -> None:
     response = app_client.get(
         "/drafts/11111111-1111-4111-8111-111111111111",
         headers=headers_for(USER),
@@ -202,18 +187,14 @@ def test_get_draft_unknown_id_returns_404(
     assert response.status_code == 404
 
 
-def test_drafts_isolated_between_users(
-    app_client: TestClient, headers_for
-) -> None:
+def test_drafts_isolated_between_users(app_client: TestClient, headers_for) -> None:
     response = app_client.post(
         "/drafts/",
         json={"subject": "Private", "body": "Draft"},
         headers=headers_for(USER),
     )
     draft_id = response.json()["entry"]["draft"]["draft_id"]
-    response = app_client.get(
-        f"/drafts/{draft_id}", headers=headers_for(OTHER_USER)
-    )
+    response = app_client.get(f"/drafts/{draft_id}", headers=headers_for(OTHER_USER))
     assert response.status_code == 404
 
 
@@ -279,9 +260,7 @@ def test_send_draft_rejects_invalid_recipients(
     assert response.status_code == 422
 
 
-def test_send_unknown_draft_returns_404(
-    app_client: TestClient, headers_for
-) -> None:
+def test_send_unknown_draft_returns_404(app_client: TestClient, headers_for) -> None:
     response = app_client.post(
         "/drafts/11111111-1111-4111-8111-111111111111/send",
         json={"recipients": [OTHER_USER]},
@@ -332,16 +311,12 @@ def test_trash_open_returns_entry(
     app_client: TestClient, headers_for, backend: MemoryBackend
 ) -> None:
     message_id = _seed_trash(backend, USER)
-    response = app_client.get(
-        f"/trash/{message_id}", headers=headers_for(USER)
-    )
+    response = app_client.get(f"/trash/{message_id}", headers=headers_for(USER))
     assert response.status_code == 200
     assert response.json()["entry"]["message"]["subject"] == "Trashed"
 
 
-def test_trash_open_unknown_id_returns_404(
-    app_client: TestClient, headers_for
-) -> None:
+def test_trash_open_unknown_id_returns_404(app_client: TestClient, headers_for) -> None:
     response = app_client.get(
         "/trash/11111111-1111-4111-8111-111111111111",
         headers=headers_for(USER),
@@ -353,7 +328,163 @@ def test_trash_isolated_between_users(
     app_client: TestClient, headers_for, backend: MemoryBackend
 ) -> None:
     message_id = _seed_trash(backend, USER)
-    response = app_client.get(
-        f"/trash/{message_id}", headers=headers_for(OTHER_USER)
-    )
+    response = app_client.get(f"/trash/{message_id}", headers=headers_for(OTHER_USER))
     assert response.status_code == 404
+
+
+# ─── Box query parameters ──────────────────────────────────────────
+
+
+def _seed_trash_n(backend: MemoryBackend, owner: str, n: int) -> list[str]:
+    """
+    Seed ``n`` trash entries for ``owner``. ``trashed_at`` *increases* with
+    insertion order while the underlying message's ``sent_at`` *decreases*, so
+    sorting by ``entered_at`` (trashed_at) and by ``sent_at`` produce opposite
+    orders — letting a single seed exercise both. Returns the message IDs in
+    insertion order (oldest-trashed first), so ``ids[-1]`` is the newest.
+
+    The message is also registered in ``backend.messages`` because the
+    ``sent_at`` sort resolves send time via that store (as the real local
+    delivery path populates it).
+    """
+
+    ids: list[str] = []
+    for i in range(n):
+        message_id = f"{i:08d}-2222-4222-8222-222222222222"
+        message = MAILMessage(
+            message_id=message_id,
+            sender="sage@chorus@localhost",
+            recipients=[owner],
+            subject=f"Trashed {i}",
+            body="body",
+            sent_at=datetime(2026, 6, 1, 12, n - i, tzinfo=UTC),  # decreasing
+            metadata={},
+        )
+        backend.messages[message_id] = message
+        backend.trash_entries[message_id] = MAILTrashEntry(
+            message=message,
+            trashed_at=datetime(2026, 6, 11, 12, i, tzinfo=UTC),  # increasing
+        )
+        backend.trashes[owner].append(message_id)
+        ids.append(message_id)
+    return ids
+
+
+def test_box_metadata_reports_pagination_defaults(
+    app_client: TestClient, headers_for
+) -> None:
+    """An empty box still echoes the applied (default) filters."""
+
+    response = app_client.get("/inbox/", headers=headers_for(USER))
+    assert response.status_code == 200
+    assert response.json()["metadata"] == {
+        "total": 0,
+        "returned": 0,
+        "limit": 20,
+        "offset": 0,
+        "sort_by": "entered_at",
+        "order": "desc",
+    }
+
+
+def test_box_rejects_unknown_query_param(app_client: TestClient, headers_for) -> None:
+    """`extra="forbid"` makes an unknown query param a 422."""
+
+    response = app_client.get("/inbox/?bogus=1", headers=headers_for(USER))
+    assert response.status_code == 422
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "limit=0",
+        "limit=101",
+        "limit=abc",
+        "offset=-1",
+        "sort_by=bogus",
+        "order=sideways",
+    ],
+)
+def test_box_rejects_invalid_query_params(
+    app_client: TestClient, headers_for, query: str
+) -> None:
+    response = app_client.get(f"/inbox/?{query}", headers=headers_for(USER))
+    assert response.status_code == 422
+
+
+def test_box_pagination_slices_and_counts(
+    app_client: TestClient, headers_for, backend: MemoryBackend
+) -> None:
+    ids = _seed_trash_n(backend, USER, 5)  # oldest → newest
+
+    response = app_client.get("/trash/?limit=2&offset=0", headers=headers_for(USER))
+    assert response.status_code == 200
+    body = response.json()
+    # default sort is entered_at (trashed_at) descending → newest first
+    assert [e["message_id"] for e in body["entries"]] == [ids[4], ids[3]]
+    assert body["metadata"]["total"] == 5
+    assert body["metadata"]["returned"] == 2
+
+    response = app_client.get("/trash/?limit=2&offset=2", headers=headers_for(USER))
+    assert [e["message_id"] for e in response.json()["entries"]] == [ids[2], ids[1]]
+
+
+def test_box_sort_order_ascending(
+    app_client: TestClient, headers_for, backend: MemoryBackend
+) -> None:
+    ids = _seed_trash_n(backend, USER, 3)
+
+    response = app_client.get("/trash/?order=asc", headers=headers_for(USER))
+    assert response.status_code == 200
+    assert [e["message_id"] for e in response.json()["entries"]] == ids
+
+
+def test_box_offset_past_end_returns_empty_page(
+    app_client: TestClient, headers_for, backend: MemoryBackend
+) -> None:
+    _seed_trash_n(backend, USER, 3)
+
+    response = app_client.get("/trash/?offset=10", headers=headers_for(USER))
+    assert response.status_code == 200
+    body = response.json()
+    assert body["entries"] == []
+    assert body["metadata"]["total"] == 3
+    assert body["metadata"]["returned"] == 0
+
+
+def test_box_sort_by_sent_at_uses_message_send_time(
+    app_client: TestClient, headers_for, backend: MemoryBackend
+) -> None:
+    """
+    `sort_by=sent_at` orders by the underlying message's send time, which the
+    seed makes the exact reverse of the default `entered_at` (trashed_at) order.
+    """
+
+    ids = _seed_trash_n(backend, USER, 3)
+
+    default = app_client.get("/trash/", headers=headers_for(USER))
+    assert [e["message_id"] for e in default.json()["entries"]] == [
+        ids[2],
+        ids[1],
+        ids[0],
+    ]
+
+    by_sent = app_client.get("/trash/?sort_by=sent_at", headers=headers_for(USER))
+    assert by_sent.status_code == 200
+    assert [e["message_id"] for e in by_sent.json()["entries"]] == [
+        ids[0],
+        ids[1],
+        ids[2],
+    ]
+
+
+def test_drafts_reject_sort_by_sent_at(app_client: TestClient, headers_for) -> None:
+    """Drafts have no send time, so `sort_by=sent_at` must 422 (not silently fall back)."""
+
+    response = app_client.get("/drafts/?sort_by=sent_at", headers=headers_for(USER))
+    assert response.status_code == 422
+    # other boxes still accept it
+    assert (
+        app_client.get("/inbox/?sort_by=sent_at", headers=headers_for(USER)).status_code
+        == 200
+    )

--- a/tests/integration/test_stubs.py
+++ b/tests/integration/test_stubs.py
@@ -39,7 +39,7 @@ def test_delete_inbox_message_moves_to_trash(
 def test_delete_draft_removes_it(app_client: TestClient, headers_for) -> None:
     headers = headers_for(USER)
     response = app_client.post(
-        "/drafts/",
+        "/drafts",
         json={"subject": "Disposable", "body": "Delete me"},
         headers=headers,
     )
@@ -49,9 +49,7 @@ def test_delete_draft_removes_it(app_client: TestClient, headers_for) -> None:
 
 
 @stub
-def test_delete_trashed_message_removes_it(
-    app_client: TestClient, headers_for
-) -> None:
+def test_delete_trashed_message_removes_it(app_client: TestClient, headers_for) -> None:
     response = app_client.delete(
         "/trash/11111111-1111-4111-8111-111111111111",
         headers=headers_for(USER),

--- a/tests/integration/test_swarms.py
+++ b/tests/integration/test_swarms.py
@@ -35,7 +35,7 @@ def test_health_reports_ok_without_auth(app_client: TestClient) -> None:
 
 
 @pytest.mark.parametrize(
-    "path", ["/swarms/", f"/swarms/{SWARM}", f"/swarms/{SWARM}/health"]
+    "path", ["/swarms", f"/swarms/{SWARM}", f"/swarms/{SWARM}/health"]
 )
 def test_swarm_endpoints_reject_missing_token(
     app_client: TestClient, path: str
@@ -44,10 +44,8 @@ def test_swarm_endpoints_reject_missing_token(
     assert response.status_code == 401
 
 
-def test_get_swarms_lists_seeded_swarm(
-    app_client: TestClient, headers_for
-) -> None:
-    response = app_client.get("/swarms/", headers=headers_for(USER))
+def test_get_swarms_lists_seeded_swarm(app_client: TestClient, headers_for) -> None:
+    response = app_client.get("/swarms", headers=headers_for(USER))
     assert response.status_code == 200
     swarms = response.json()["swarms"]
     assert len(swarms) == 1
@@ -60,17 +58,13 @@ def test_get_swarm_by_name(app_client: TestClient, headers_for) -> None:
     assert response.json()["swarm"]["name"] == SWARM
 
 
-def test_get_swarm_unknown_returns_404(
-    app_client: TestClient, headers_for
-) -> None:
+def test_get_swarm_unknown_returns_404(app_client: TestClient, headers_for) -> None:
     response = app_client.get("/swarms/nonexistent", headers=headers_for(USER))
     assert response.status_code == 404
 
 
 def test_get_swarm_health(app_client: TestClient, headers_for) -> None:
-    response = app_client.get(
-        f"/swarms/{SWARM}/health", headers=headers_for(USER)
-    )
+    response = app_client.get(f"/swarms/{SWARM}/health", headers=headers_for(USER))
     assert response.status_code == 200
     assert response.json()["status"] == "ok"
 
@@ -78,7 +72,5 @@ def test_get_swarm_health(app_client: TestClient, headers_for) -> None:
 def test_get_swarm_health_unknown_returns_404(
     app_client: TestClient, headers_for
 ) -> None:
-    response = app_client.get(
-        "/swarms/nonexistent/health", headers=headers_for(USER)
-    )
+    response = app_client.get("/swarms/nonexistent/health", headers=headers_for(USER))
     assert response.status_code == 404

--- a/tests/unit/test_client_commands.py
+++ b/tests/unit/test_client_commands.py
@@ -125,7 +125,7 @@ def test_inbox_sends_bearer_token_and_lists_entries(
         "received_at": "2026-06-12T09:00:00+00:00",
         "delivered_by": "daemon:dummy@localhost",
     }
-    route = respx.get(f"{SERVER}/inbox/").mock(
+    route = respx.get(f"{SERVER}/inbox").mock(
         return_value=httpx.Response(200, json={"entries": [entry], "metadata": {}})
     )
     cmd_inbox(Namespace(output="text"))
@@ -147,9 +147,7 @@ def test_inbox_requires_mail_token_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @respx.mock
-def test_compose_posts_draft_payload(
-    client_env, capsys: pytest.CaptureFixture
-) -> None:
+def test_compose_posts_draft_payload(client_env, capsys: pytest.CaptureFixture) -> None:
     draft = {
         "draft_id": "55555555-5555-4555-8555-555555555555",
         "subject": "A subject",
@@ -157,7 +155,7 @@ def test_compose_posts_draft_payload(
         "created_at": "2026-06-12T09:00:00+00:00",
         "updated_at": None,
     }
-    route = respx.post(f"{SERVER}/drafts/").mock(
+    route = respx.post(f"{SERVER}/drafts").mock(
         return_value=httpx.Response(
             200,
             json={
@@ -202,9 +200,7 @@ def test_send_posts_recipients_to_draft_endpoint(
     route = respx.post(f"{SERVER}/drafts/{draft_id}/send").mock(
         return_value=httpx.Response(200, json={"message": message, "metadata": {}})
     )
-    cmd_send(
-        Namespace(output="text", draft_id=draft_id, to=["sage@chorus@localhost"])
-    )
+    cmd_send(Namespace(output="text", draft_id=draft_id, to=["sage@chorus@localhost"]))
 
     request = route.calls[0].request
     assert json.loads(request.content) == {"recipients": ["sage@chorus@localhost"]}


### PR DESCRIPTION
## Summary

Two related improvements to the user-agent message-box HTTP surface, building on the `BoxFilterParams` model:

1. **Query params for box listings** — `limit`, `offset`, `sort_by`, `order` on `GET /inbox`, `/outbox`, `/trash`, `/drafts`.
2. **Slash-free collection endpoints** — drop the trailing slash from the box and swarm collection roots for consistency with the rest of the surface.

## 1. Box query parameters

Wires `BoxFilterParams` (`limit`/`offset`/`sort_by`/`order`) into the four box GET endpoints.

- **Parsing/validation** — `validate_box_filter_params` mirrors the existing body-validator idiom: unknown params and out-of-bounds values `422` (the model is `extra="forbid"`).
- **Filtering pushed into the backend** — `get_inbox/outbox/trash/drafts` now take a `BoxFilterParams` and return `(page, total)`; `MemoryBackend` sorts + slices.
- **`sort_by` semantics** — two genuinely distinct options:
  - `entered_at` (default): when the entry landed in *this* box (`received_at` / `sent_at` / `trashed_at` / `created_at`).
  - `sent_at`: the underlying `MAILMessage.sent_at` (original send time) — a real, distinct ordering for inbox/trash. Drafts have no send time, so `GET /drafts?sort_by=sent_at` returns `422`.
- **Pagination metadata** — each response now populates `metadata` with `{total, returned, limit, offset, sort_by, order}`.
- **Client** — `--limit/--offset/--sort-by/--order` flags on the four box commands.

### Federation note
The `sent_at` sort resolves send time via `backend.messages`. The local delivery path always populates it; `deliver_remote` (currently a `NotImplementedError` stub) MUST populate `backend.messages` when implemented, or `sort_by=sent_at` on a federated entry would `KeyError`.

## 2. Slash-free box/swarm endpoints

The box and swarm collection roots were the only endpoints registered as `"/"`, yielding `GET /inbox/`, `/outbox/`, `/trash/`, `/drafts/`, `/swarms/` (and `POST /drafts/`) — inconsistent with the rest of the surface (`/auth/token`, `/admin/agents`, …), which uses no trailing slash. They now register with `""` so the canonical path is slash-free.

- Routers, client commands, and tests updated to the canonical paths.
- `spec/openapi.yaml` regenerated; the contract drift test confirms it matches the app.
- **Backward compatible:** FastAPI's default `redirect_slashes` still 307-redirects the old `/inbox/` form to `/inbox`.
- `POST /drafts` is included (shares the same root as `GET /drafts`) so the inconsistency isn't just relocated to the POST.

## Testing

- Full suite: **387 passed, 6 xfailed** (incl. the OpenAPI contract drift test)
- e2e: **4 passed**
- ruff `check` + `format`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)