### PR TITLE
chore: rebrand CLI copyright to MAIL Contributors and add --license

### DIFF
--- a/src/mail/protocol/src/mail_protocol/cli_help.py
+++ b/src/mail/protocol/src/mail_protocol/cli_help.py
@@ -9,6 +9,42 @@ from collections.abc import Sequence
 CommandHelp = tuple[str, str]
 CommandGroup = tuple[str, Sequence[CommandHelp]]
 
+LICENSE_NOTICE = """\
+MAIL - Multi-Agent Interface Layer
+Copyright (c) 2025-present MAIL Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this software except in compliance with the License.
+You may obtain a copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the LICENSE and NOTICE files
+distributed with this project for the full terms."""
+
+
+class _LicenseAction(argparse.Action):
+    """Print MAIL's license notice and exit, mirroring argparse's --version."""
+
+    def __init__(
+        self,
+        option_strings: Sequence[str],
+        dest: str = argparse.SUPPRESS,
+        default: str = argparse.SUPPRESS,
+        help: str = "show license information and exit",
+    ):
+        super().__init__(
+            option_strings=option_strings,
+            dest=dest,
+            default=default,
+            nargs=0,
+            help=help,
+        )
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        parser.exit(message=LICENSE_NOTICE + "\n")
+
 
 class MAILHelpFormatter(
     argparse.ArgumentDefaultsHelpFormatter,
@@ -24,7 +60,7 @@ def build_epilog(
     *,
     command_groups: Sequence[CommandGroup] | None = None,
     examples: Sequence[str] | None = None,
-    footer: str | None = "Copyright (c) 2026 Addison Kline",
+    footer: str | None = "Copyright (c) 2025-present MAIL Contributors",
 ) -> str | None:
     sections: list[str] = []
 
@@ -51,6 +87,11 @@ def build_epilog(
     return "\n\n".join(sections)
 
 
+def add_license_argument(parser: argparse.ArgumentParser) -> None:
+    """Add a `--license` flag that prints MAIL's license notice and exits."""
+    parser.add_argument("--license", action=_LicenseAction)
+
+
 def make_arg_parser(
     *,
     prog: str,
@@ -59,13 +100,15 @@ def make_arg_parser(
     command_groups: Sequence[CommandGroup] | None = None,
     examples: Sequence[str] | None = None,
 ) -> argparse.ArgumentParser:
-    return argparse.ArgumentParser(
+    parser = argparse.ArgumentParser(
         prog=prog,
         usage=usage,
         description=description,
         epilog=build_epilog(command_groups=command_groups, examples=examples),
         formatter_class=MAILHelpFormatter,
     )
+    add_license_argument(parser)
+    return parser
 
 
 def add_hidden_subparsers(parser: argparse.ArgumentParser):

--- a/src/mail/server/src/mail_server/backend_init.py
+++ b/src/mail/server/src/mail_server/backend_init.py
@@ -3,6 +3,7 @@
 
 import argparse
 
+from mail_protocol.cli_help import add_license_argument
 from mail_protocol.core.validators import (
     validate_agent_names,
     validate_daemon_worker_names,
@@ -21,8 +22,9 @@ def main() -> None:
         prog="backend-init",
         usage="backend-init [option]...",
         description="Initialize the MAIL server backend for use by mail-server",
-        epilog="Copyright (c) 2026 Addison Kline",
+        epilog="Copyright (c) 2025-present MAIL Contributors",
     )
+    add_license_argument(parser)
     parser.add_argument(
         "-t",
         "--type",


### PR DESCRIPTION
## Summary

Updates the user-facing copyright notice in the MAIL CLIs and adds a `--license` flag.

- Change the displayed copyright in `--help` footers and the `backend-init` epilog from `Copyright (c) 2026 Addison Kline` to **`Copyright (c) 2025-present MAIL Contributors`**.
- Add a shared `--license` flag (via `cli_help`) that prints MAIL's Apache-2.0 notice and exits. It's wired into `make_arg_parser`, so `mail`, `mail-server`, and `mail-daemon` all get it; `backend-init` opts in explicitly.

The `2025-present` form preserves the v1 (2025) publication year, stays static (no runtime `datetime` dependency), and never needs updating.

Per-file header comments are intentionally left unchanged — those are per-file authorship records, distinct from the project's user-facing copyright notice.

## Test plan

- [x] `mail`, `mail-server`, `mail-daemon`, `backend-init` all show the new footer and `--license` notice
- [x] `tests/unit/test_cli_help.py` passes (13/13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)